### PR TITLE
feat: Dependabot integration + escalate state + branch propagation (#65, #70, #71)

### DIFF
--- a/docs/dev-notes.md
+++ b/docs/dev-notes.md
@@ -1,11 +1,15 @@
 # HexOps Development Notes
 
-**Current Version:** 0.10.2
+**Current Version:** 0.12.0
 **Purpose:** Internal development operations dashboard for managing Hexaxia project dev servers. Start/stop projects, view logs, manage patches, and monitor status from a single interface.
 
 ---
 
 ## Version History
+
+### v0.12.0 (2026-04-17)
+- **Feature:** Dependabot integration — projects managed by Dependabot switch to read-only monitor mode in the Patches dashboard, showing open PRs with merge/conflict status and direct GitHub links
+- **Fix:** App version now sourced from package.json automatically — no more manual sync required
 
 ### v0.10.2 (2026-03-21)
 - **Feature:** Progressive loading with SSE for patches dashboard

--- a/docs/superpowers/plans/2026-04-21-hexops-branch-propagation.md
+++ b/docs/superpowers/plans/2026-04-21-hexops-branch-propagation.md
@@ -1,0 +1,1032 @@
+# HexOps Branch Propagation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect when active git branches are behind `main` on `package.json` deps (after a Dependabot merge), and let the user sync them via a PR or direct push from the Dependabot panel.
+
+**Architecture:** `branch-propagator.ts` owns all git operations (branch listing, dep comparison, worktree-based sync). Two new API routes expose this to the frontend. `DependabotPanel` self-fetches branch sync status and surfaces a warning banner + `BranchPropagateModal`.
+
+**Tech Stack:** Next.js 15 App Router, TypeScript, `execFile` (promisified) for git ops, GitHub REST API for PR creation, existing `detectPackageManager` / `lockfile-resolver.ts` patterns, shadcn/ui components.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/lib/types.ts` | Modify | Add `BranchSyncStatus`, `PropagationConfig`; extend `ProjectConfig` |
+| `src/lib/github-client.ts` | Modify | Add `openPropagationPR` function |
+| `src/lib/branch-propagator.ts` | **Create** | `getActiveBranches`, `getBranchSyncStatuses`, `propagateBranch` |
+| `src/app/api/projects/[id]/branch-sync/route.ts` | **Create** | GET — list branch sync statuses |
+| `src/app/api/projects/[id]/propagate-branches/route.ts` | **Create** | POST — execute propagation |
+| `src/components/branch-propagate-modal.tsx` | **Create** | Branch selection + live result UI |
+| `src/components/detail-sections/dependabot-panel.tsx` | Modify | Add sync warning banner + Propagate button |
+
+---
+
+### Task 1: Add types to `types.ts`
+
+**Files:**
+- Modify: `src/lib/types.ts`
+
+**Context:** `ProjectConfig` is at line 28. `DependabotConfig` is at line 177. No test runner exists — use `pnpm tsc --noEmit` from `/home/aaron/Projects/hexops` for verification.
+
+- [ ] **Step 1: Add `BranchSyncStatus` and `PropagationConfig` after `DependabotConfig` (after line 184)**
+
+```typescript
+export interface BranchSyncStatus {
+  branch: string;
+  status: 'synced' | 'out_of_sync' | 'conflict' | 'propagated';
+  prUrl?: string;
+  error?: string;
+}
+
+export interface PropagationConfig {
+  activeBranchDays: number;
+  openPR: boolean;
+  autoPush: boolean;
+}
+```
+
+- [ ] **Step 2: Add `propagation` field to `ProjectConfig` (after the `github?` field at line 46)**
+
+```typescript
+propagation?: Partial<PropagationConfig>;
+```
+
+- [ ] **Step 3: Verify TypeScript**
+
+```bash
+cd /home/aaron/Projects/hexops && pnpm tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/aaron/Projects/hexops && git commit src/lib/types.ts -m "feat(branch-prop): add BranchSyncStatus and PropagationConfig types (#71)"
+```
+
+---
+
+### Task 2: Add `openPropagationPR` to `github-client.ts`
+
+**Files:**
+- Modify: `src/lib/github-client.ts`
+
+**Context:** File already has `fetchDependabotPRs` using `fetch` with GitHub API. Follow the same pattern. Add after the existing `mapPR` function at the bottom of the file.
+
+- [ ] **Step 1: Add the `openPropagationPR` function at the end of `src/lib/github-client.ts`**
+
+```typescript
+/**
+ * Opens a PR on GitHub from `head` branch targeting `base` branch.
+ * Returns the PR's html_url.
+ * Throws if token is missing or API call fails.
+ */
+export async function openPropagationPR(
+  owner: string,
+  repo: string,
+  head: string,
+  base: string,
+  token: string | null
+): Promise<string> {
+  if (!token) throw new Error('GitHub token required to open PRs');
+
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
+
+  const url = `${GITHUB_API}/repos/${owner}/${repo}/pulls`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      title: `chore: sync package.json deps from main → ${base}`,
+      head,
+      base,
+      body: 'Automated branch propagation by HexOps. Syncs `package.json` deps from `main` and regenerates the lockfile.\n\nReview the diff and merge when ready.',
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`GitHub PR creation failed (${response.status}): ${text}`);
+  }
+
+  const pr = (await response.json()) as { html_url: string };
+  return pr.html_url;
+}
+```
+
+- [ ] **Step 2: Verify TypeScript**
+
+```bash
+cd /home/aaron/Projects/hexops && pnpm tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/aaron/Projects/hexops && git commit src/lib/github-client.ts -m "feat(branch-prop): add openPropagationPR to github-client (#71)"
+```
+
+---
+
+### Task 3: Create `src/lib/branch-propagator.ts`
+
+**Files:**
+- Create: `src/lib/branch-propagator.ts`
+
+**Context:**
+- `detectPackageManager` is exported from `src/lib/patch-scanner.ts`
+- Use `execFile` + `promisify` pattern (same as `src/app/api/projects/[id]/escalate/route.ts`)
+- `openPropagationPR` is in `src/lib/github-client.ts` (Task 2)
+- `PropagationConfig`, `BranchSyncStatus` are in `src/lib/types.ts` (Task 1)
+- Default `PropagationConfig`: `{ activeBranchDays: 30, openPR: true, autoPush: false }`
+
+```typescript
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { detectPackageManager } from './patch-scanner';
+import { openPropagationPR } from './github-client';
+import type { BranchSyncStatus, PropagationConfig } from './types';
+
+const execFileAsync = promisify(execFile);
+
+export const DEFAULT_PROPAGATION_CONFIG: PropagationConfig = {
+  activeBranchDays: 30,
+  openPR: true,
+  autoPush: false,
+};
+
+const LOCK_FILES: Record<string, string> = {
+  pnpm: 'pnpm-lock.yaml',
+  npm: 'package-lock.json',
+  yarn: 'yarn.lock',
+};
+
+const INSTALL_CMD: Record<string, string[]> = {
+  pnpm: ['pnpm', 'install', '--no-frozen-lockfile'],
+  npm: ['npm', 'install', '--legacy-peer-deps'],
+  yarn: ['yarn', 'install'],
+};
+```
+
+- [ ] **Step 1: Create `src/lib/branch-propagator.ts` with the header above plus `getActiveBranches`**
+
+```typescript
+/**
+ * Lists active remote branches (excluding main/master/HEAD) with a commit
+ * within the last `days` days. Runs `git fetch` first to ensure current data.
+ */
+export async function getActiveBranches(
+  projectPath: string,
+  days: number
+): Promise<string[]> {
+  await execFileAsync('git', ['fetch', 'origin', '--prune'], {
+    cwd: projectPath,
+    timeout: 30000,
+  });
+
+  const { stdout } = await execFileAsync(
+    'git',
+    [
+      'for-each-ref',
+      '--sort=-committerdate',
+      '--format=%(refname:short) %(committerdate:iso-strict)',
+      'refs/remotes/origin/',
+    ],
+    { cwd: projectPath, timeout: 10000 }
+  );
+
+  const SKIP = new Set(['origin/main', 'origin/master', 'origin/HEAD']);
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+  const branches: string[] = [];
+
+  for (const line of stdout.trim().split('\n')) {
+    if (!line.trim()) continue;
+    const spaceIdx = line.indexOf(' ');
+    const refname = line.slice(0, spaceIdx);
+    const date = line.slice(spaceIdx + 1).trim();
+    if (SKIP.has(refname)) continue;
+    if (date >= cutoff) {
+      branches.push(refname.replace('origin/', ''));
+    }
+  }
+
+  return branches;
+}
+```
+
+- [ ] **Step 2: Add `getBranchSyncStatuses` to the same file**
+
+```typescript
+interface DepSnapshot {
+  dependencies: Record<string, string>;
+  devDependencies: Record<string, string>;
+  overrides: Record<string, string>;
+  pnpmOverrides: Record<string, string>;
+  resolutions: Record<string, string>;
+}
+
+function extractDeps(pkg: Record<string, unknown>): DepSnapshot {
+  const pnpm = (pkg.pnpm ?? {}) as Record<string, unknown>;
+  return {
+    dependencies: (pkg.dependencies ?? {}) as Record<string, string>,
+    devDependencies: (pkg.devDependencies ?? {}) as Record<string, string>,
+    overrides: (pkg.overrides ?? {}) as Record<string, string>,
+    pnpmOverrides: ((pnpm.overrides ?? {}) as Record<string, string>),
+    resolutions: (pkg.resolutions ?? {}) as Record<string, string>,
+  };
+}
+
+function depsEqual(a: DepSnapshot, b: DepSnapshot): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Compares package.json dep sections on each branch against origin/main.
+ * Runs comparisons in parallel. Branches that can't be read are treated as synced.
+ */
+export async function getBranchSyncStatuses(
+  projectPath: string,
+  branches: string[]
+): Promise<BranchSyncStatus[]> {
+  const { stdout: mainPkgRaw } = await execFileAsync(
+    'git',
+    ['show', 'origin/main:package.json'],
+    { cwd: projectPath, timeout: 10000 }
+  );
+  const mainDeps = extractDeps(JSON.parse(mainPkgRaw) as Record<string, unknown>);
+
+  return Promise.all(
+    branches.map(async (branch): Promise<BranchSyncStatus> => {
+      try {
+        const { stdout: branchPkgRaw } = await execFileAsync(
+          'git',
+          ['show', `origin/${branch}:package.json`],
+          { cwd: projectPath, timeout: 10000 }
+        );
+        const branchDeps = extractDeps(JSON.parse(branchPkgRaw) as Record<string, unknown>);
+        return {
+          branch,
+          status: depsEqual(mainDeps, branchDeps) ? 'synced' : 'out_of_sync',
+        };
+      } catch {
+        return { branch, status: 'synced' };
+      }
+    })
+  );
+}
+```
+
+- [ ] **Step 3: Add `propagateBranch` to the same file**
+
+```typescript
+/**
+ * Syncs package.json from origin/main onto `branch`, regenerates the lockfile,
+ * then either opens a GitHub PR or pushes directly per `config`.
+ *
+ * Uses a git worktree so the project's working tree is not disturbed.
+ * Always removes the worktree in a finally block.
+ */
+export async function propagateBranch(
+  projectPath: string,
+  branch: string,
+  config: PropagationConfig,
+  owner: string,
+  repo: string,
+  token: string | null
+): Promise<BranchSyncStatus> {
+  const safeBranch = branch.replace(/[^a-zA-Z0-9-_]/g, '-');
+  const worktreePath = `/tmp/hexops-prop-${safeBranch}-${Date.now()}`;
+
+  try {
+    // Create worktree on target branch
+    await execFileAsync(
+      'git',
+      ['worktree', 'add', worktreePath, `origin/${branch}`],
+      { cwd: projectPath, timeout: 15000 }
+    );
+
+    // Apply package.json from main
+    try {
+      await execFileAsync(
+        'git',
+        ['checkout', 'origin/main', '--', 'package.json'],
+        { cwd: worktreePath, timeout: 10000 }
+      );
+    } catch (err) {
+      return {
+        branch,
+        status: 'conflict',
+        error: `Failed to apply package.json from main: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    // Check if anything actually changed
+    const { stdout: diffOut } = await execFileAsync(
+      'git',
+      ['diff', '--name-only'],
+      { cwd: worktreePath }
+    );
+    if (!diffOut.trim()) {
+      return { branch, status: 'synced' };
+    }
+
+    // Regenerate lockfile
+    const pm = detectPackageManager(worktreePath);
+    const [cmd, ...args] = INSTALL_CMD[pm];
+    try {
+      await execFileAsync(cmd, args, { cwd: worktreePath, timeout: 120000 });
+    } catch (err) {
+      // Revert package.json on lockfile failure
+      await execFileAsync('git', ['checkout', '--', 'package.json'], { cwd: worktreePath }).catch(() => {});
+      return {
+        branch,
+        status: 'conflict',
+        error: `Lockfile regen failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    const lockFile = LOCK_FILES[pm];
+
+    if (config.openPR) {
+      if (!token) {
+        return { branch, status: 'conflict', error: 'GitHub token required for PR mode' };
+      }
+      const syncBranch = `hexops/sync-${safeBranch}-${Date.now()}`;
+      await execFileAsync('git', ['checkout', '-b', syncBranch], { cwd: worktreePath, timeout: 5000 });
+      await execFileAsync('git', ['add', 'package.json', lockFile], { cwd: worktreePath });
+      await execFileAsync(
+        'git',
+        ['commit', '-m', `chore: sync package.json from main → ${branch}`],
+        { cwd: worktreePath, timeout: 10000 }
+      );
+      await execFileAsync('git', ['push', 'origin', syncBranch], { cwd: worktreePath, timeout: 30000 });
+      try {
+        const prUrl = await openPropagationPR(owner, repo, syncBranch, branch, token);
+        return { branch, status: 'propagated', prUrl };
+      } catch (err) {
+        return {
+          branch,
+          status: 'conflict',
+          error: `Branch pushed but PR creation failed: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+    } else {
+      await execFileAsync('git', ['add', 'package.json', lockFile], { cwd: worktreePath });
+      await execFileAsync(
+        'git',
+        ['commit', '-m', `chore: sync package.json from main → ${branch}`],
+        { cwd: worktreePath, timeout: 10000 }
+      );
+      await execFileAsync(
+        'git',
+        ['push', 'origin', `HEAD:${branch}`],
+        { cwd: worktreePath, timeout: 30000 }
+      );
+      return { branch, status: 'propagated' };
+    }
+  } finally {
+    await execFileAsync(
+      'git',
+      ['worktree', 'remove', '--force', worktreePath],
+      { cwd: projectPath, timeout: 10000 }
+    ).catch(() => {});
+  }
+}
+```
+
+- [ ] **Step 4: Verify TypeScript**
+
+```bash
+cd /home/aaron/Projects/hexops && pnpm tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/aaron/Projects/hexops && git add src/lib/branch-propagator.ts && git commit -m "feat(branch-prop): add branch-propagator lib (#71)"
+```
+
+---
+
+### Task 4: Create `GET /api/projects/[id]/branch-sync` route
+
+**Files:**
+- Create: `src/app/api/projects/[id]/branch-sync/route.ts`
+
+**Context:** Follow the pattern from `src/app/api/projects/[id]/dependabot/route.ts`. `getProject` and `loadConfig` are from `@/lib/config`. `DEFAULT_PROPAGATION_CONFIG` is from `@/lib/branch-propagator`.
+
+- [ ] **Step 1: Create `src/app/api/projects/[id]/branch-sync/route.ts`**
+
+```typescript
+import { NextResponse } from 'next/server';
+import { getProject, loadConfig } from '@/lib/config';
+import {
+  getActiveBranches,
+  getBranchSyncStatuses,
+  DEFAULT_PROPAGATION_CONFIG,
+} from '@/lib/branch-propagator';
+import type { PropagationConfig } from '@/lib/types';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const project = getProject(id);
+
+  if (!project) {
+    return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+  }
+
+  const config: PropagationConfig = {
+    ...DEFAULT_PROPAGATION_CONFIG,
+    ...project.propagation,
+  };
+
+  try {
+    const activeBranches = await getActiveBranches(project.path, config.activeBranchDays);
+
+    if (activeBranches.length === 0) {
+      return NextResponse.json({ branches: [], config });
+    }
+
+    const branches = await getBranchSyncStatuses(project.path, activeBranches);
+    return NextResponse.json({ branches, config });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Branch sync check failed' },
+      { status: 500 }
+    );
+  }
+}
+```
+
+- [ ] **Step 2: Verify TypeScript**
+
+```bash
+cd /home/aaron/Projects/hexops && pnpm tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/aaron/Projects/hexops && git add src/app/api/projects/\[id\]/branch-sync/ && git commit -m "feat(branch-prop): add GET branch-sync API route (#71)"
+```
+
+---
+
+### Task 5: Create `POST /api/projects/[id]/propagate-branches` route
+
+**Files:**
+- Create: `src/app/api/projects/[id]/propagate-branches/route.ts`
+
+**Context:** Follow `src/app/api/projects/[id]/escalate/route.ts` for the pattern. `getProject`, `loadConfig` from `@/lib/config`. `propagateBranch`, `DEFAULT_PROPAGATION_CONFIG` from `@/lib/branch-propagator`. GitHub token from `config.settings?.integrations?.github?.token`. `owner`/`repo` from `project.github` or fall back to detecting via `parseGitHubRemote` from `@/lib/dependabot-detector`.
+
+- [ ] **Step 1: Create `src/app/api/projects/[id]/propagate-branches/route.ts`**
+
+```typescript
+import { NextRequest, NextResponse } from 'next/server';
+import { getProject, loadConfig } from '@/lib/config';
+import { propagateBranch, DEFAULT_PROPAGATION_CONFIG } from '@/lib/branch-propagator';
+import { parseGitHubRemote } from '@/lib/dependabot-detector';
+import type { BranchSyncStatus, PropagationConfig } from '@/lib/types';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const project = getProject(id);
+
+  if (!project) {
+    return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+  }
+
+  const body = await request.json().catch(() => null);
+  if (!body || !Array.isArray(body.branches) || body.branches.length === 0) {
+    return NextResponse.json({ error: 'branches array required' }, { status: 400 });
+  }
+
+  const branches = body.branches as string[];
+  const openPROverride: boolean | undefined =
+    typeof body.openPR === 'boolean' ? body.openPR : undefined;
+
+  const globalConfig = loadConfig();
+  const token = globalConfig.settings?.integrations?.github?.token ?? null;
+
+  const propagationConfig: PropagationConfig = {
+    ...DEFAULT_PROPAGATION_CONFIG,
+    ...project.propagation,
+    ...(openPROverride !== undefined ? { openPR: openPROverride } : {}),
+  };
+
+  // Resolve owner/repo
+  let owner = project.github?.owner ?? null;
+  let repo = project.github?.repo ?? null;
+  if (!owner || !repo) {
+    const remote = await parseGitHubRemote(project.path);
+    owner = remote.owner;
+    repo = remote.repo;
+  }
+
+  if (propagationConfig.openPR && (!owner || !repo)) {
+    return NextResponse.json(
+      { error: 'Could not determine GitHub owner/repo — configure project.github or ensure git remote points to GitHub' },
+      { status: 422 }
+    );
+  }
+
+  const results: BranchSyncStatus[] = [];
+  const skipped: string[] = [];
+
+  for (const branch of branches) {
+    const result = await propagateBranch(
+      project.path,
+      branch,
+      propagationConfig,
+      owner ?? '',
+      repo ?? '',
+      token
+    );
+    if (result.status === 'synced') {
+      skipped.push(branch);
+    } else {
+      results.push(result);
+    }
+  }
+
+  return NextResponse.json({ results, skipped });
+}
+```
+
+- [ ] **Step 2: Verify TypeScript**
+
+```bash
+cd /home/aaron/Projects/hexops && pnpm tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/aaron/Projects/hexops && git add src/app/api/projects/\[id\]/propagate-branches/ && git commit -m "feat(branch-prop): add POST propagate-branches API route (#71)"
+```
+
+---
+
+### Task 6: Create `<BranchPropagateModal>` component
+
+**Files:**
+- Create: `src/components/branch-propagate-modal.tsx`
+
+**Context:**
+- Pattern matches `src/components/escalate-modal.tsx` (Dialog, Button, Badge from shadcn/ui, `cn` from `@/lib/utils`)
+- Import: `Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter` from `@/components/ui/dialog`
+- Import: `Button` from `@/components/ui/button`, `Badge` from `@/components/ui/badge`, `Checkbox` from `@/components/ui/checkbox`
+- `BranchSyncStatus`, `PropagationConfig` from `@/lib/types`
+- On open: GET `/api/projects/${projectId}/branch-sync` to get current statuses
+- On submit: POST `/api/projects/${projectId}/propagate-branches` with selected branches + openPR mode
+- Three UI states: loading, selection, results
+
+- [ ] **Step 1: Create `src/components/branch-propagate-modal.tsx`**
+
+```typescript
+'use client';
+
+import { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
+import { cn } from '@/lib/utils';
+import type { BranchSyncStatus, PropagationConfig } from '@/lib/types';
+
+interface BranchPropagateModalProps {
+  projectId: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function BranchPropagateModal({
+  projectId,
+  open,
+  onClose,
+}: BranchPropagateModalProps) {
+  const [loading, setLoading] = useState(true);
+  const [branches, setBranches] = useState<BranchSyncStatus[]>([]);
+  const [config, setConfig] = useState<PropagationConfig | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [openPR, setOpenPR] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [results, setResults] = useState<BranchSyncStatus[] | null>(null);
+  const [skipped, setSkipped] = useState<string[]>([]);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    setResults(null);
+    setSkipped([]);
+    setFetchError(null);
+
+    fetch(`/api/projects/${projectId}/branch-sync`)
+      .then((r) => r.json())
+      .then((data: { branches: BranchSyncStatus[]; config: PropagationConfig; error?: string }) => {
+        if (data.error) {
+          setFetchError(data.error);
+          setLoading(false);
+          return;
+        }
+        setBranches(data.branches);
+        setConfig(data.config);
+        setOpenPR(data.config.openPR);
+        // Default: select all out-of-sync branches
+        setSelected(new Set(data.branches.filter((b) => b.status === 'out_of_sync').map((b) => b.branch)));
+        setLoading(false);
+      })
+      .catch((err) => {
+        setFetchError(err instanceof Error ? err.message : 'Failed to load branch status');
+        setLoading(false);
+      });
+  }, [open, projectId]);
+
+  const toggleBranch = (branch: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(branch)) next.delete(branch);
+      else next.add(branch);
+      return next;
+    });
+  };
+
+  const handleSubmit = async () => {
+    if (selected.size === 0) return;
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/projects/${projectId}/propagate-branches`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ branches: Array.from(selected), openPR }),
+      });
+      const data = await res.json();
+      setResults(data.results ?? []);
+      setSkipped(data.skipped ?? []);
+    } catch (err) {
+      setResults([{
+        branch: 'unknown',
+        status: 'conflict',
+        error: err instanceof Error ? err.message : 'Request failed',
+      }]);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const outOfSync = branches.filter((b) => b.status === 'out_of_sync');
+  const synced = branches.filter((b) => b.status === 'synced');
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-lg bg-zinc-900 border-zinc-700">
+        <DialogHeader>
+          <DialogTitle className="text-zinc-100">Propagate Branch Dependencies</DialogTitle>
+        </DialogHeader>
+
+        {loading && (
+          <div className="flex items-center gap-2 text-sm text-zinc-400 py-4">
+            <span className="animate-spin">⟳</span> Checking branch sync status…
+          </div>
+        )}
+
+        {fetchError && (
+          <div className="rounded-md bg-red-500/10 border border-red-500/20 px-3 py-2 text-sm text-red-400">
+            {fetchError}
+          </div>
+        )}
+
+        {!loading && !fetchError && results === null && (
+          <div className="space-y-4">
+            {outOfSync.length === 0 ? (
+              <p className="text-sm text-zinc-400">All active branches are in sync with main.</p>
+            ) : (
+              <>
+                <p className="text-sm text-zinc-400">
+                  Select branches to sync with main&apos;s <code className="text-zinc-300">package.json</code>:
+                </p>
+                <div className="space-y-2">
+                  {outOfSync.map((b) => (
+                    <label
+                      key={b.branch}
+                      className={cn(
+                        'flex items-center gap-3 rounded-lg border p-3 cursor-pointer',
+                        selected.has(b.branch)
+                          ? 'border-amber-500/30 bg-amber-500/5'
+                          : 'border-zinc-700 bg-zinc-800/50'
+                      )}
+                    >
+                      <Checkbox
+                        checked={selected.has(b.branch)}
+                        onCheckedChange={() => toggleBranch(b.branch)}
+                      />
+                      <span className="font-mono text-sm text-zinc-200">{b.branch}</span>
+                      <Badge variant="outline" className="ml-auto text-xs border-amber-500/30 text-amber-400 bg-amber-500/10">
+                        Out of sync
+                      </Badge>
+                    </label>
+                  ))}
+                </div>
+
+                {synced.length > 0 && (
+                  <p className="text-xs text-zinc-500">
+                    {synced.length} branch{synced.length !== 1 ? 'es' : ''} already in sync: {synced.map((b) => b.branch).join(', ')}
+                  </p>
+                )}
+
+                {/* Mode toggle */}
+                <div className="rounded-lg border border-zinc-700 p-3 space-y-2">
+                  <p className="text-xs font-medium text-zinc-300">Delivery mode</p>
+                  <div className="flex gap-3">
+                    <label className={cn('flex items-center gap-2 text-sm cursor-pointer', openPR ? 'text-zinc-100' : 'text-zinc-500')}>
+                      <input
+                        type="radio"
+                        checked={openPR}
+                        onChange={() => setOpenPR(true)}
+                        className="accent-amber-500"
+                      />
+                      Open PR per branch
+                    </label>
+                    <label className={cn('flex items-center gap-2 text-sm cursor-pointer', !openPR ? 'text-zinc-100' : 'text-zinc-500')}>
+                      <input
+                        type="radio"
+                        checked={!openPR}
+                        onChange={() => setOpenPR(false)}
+                        className="accent-amber-500"
+                      />
+                      Push directly
+                    </label>
+                  </div>
+                  {openPR && (
+                    <p className="text-xs text-zinc-500">Requires GitHub token in Settings.</p>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        {results !== null && (
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-zinc-300">Results</p>
+            {results.map((r) => (
+              <div
+                key={r.branch}
+                className={cn(
+                  'flex items-start gap-3 rounded-lg border p-3 text-sm',
+                  r.status === 'propagated'
+                    ? 'border-green-500/20 bg-green-500/5'
+                    : 'border-red-500/20 bg-red-500/5'
+                )}
+              >
+                <span>{r.status === 'propagated' ? '✅' : '⚠️'}</span>
+                <div className="flex-1 min-w-0">
+                  <span className="font-mono text-zinc-200">{r.branch}</span>
+                  {r.status === 'propagated' && r.prUrl && (
+                    <a
+                      href={r.prUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="block text-xs text-amber-400 hover:text-amber-300 underline mt-1"
+                    >
+                      View PR →
+                    </a>
+                  )}
+                  {r.status === 'propagated' && !r.prUrl && (
+                    <p className="text-xs text-green-400 mt-1">Pushed directly to branch</p>
+                  )}
+                  {r.status === 'conflict' && (
+                    <p className="text-xs text-red-400 mt-1">{r.error}</p>
+                  )}
+                </div>
+              </div>
+            ))}
+            {skipped.length > 0 && (
+              <p className="text-xs text-zinc-500">
+                Skipped (already in sync): {skipped.join(', ')}
+              </p>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          {results === null ? (
+            <>
+              <Button variant="ghost" onClick={onClose} className="text-zinc-400">
+                Cancel
+              </Button>
+              <Button
+                onClick={handleSubmit}
+                disabled={submitting || selected.size === 0 || loading}
+                className="bg-amber-600 hover:bg-amber-500 text-white"
+              >
+                {submitting ? 'Propagating…' : `Propagate ${selected.size > 0 ? `(${selected.size})` : ''}`}
+              </Button>
+            </>
+          ) : (
+            <Button onClick={onClose} className="bg-zinc-700 hover:bg-zinc-600 text-zinc-100">
+              Done
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript**
+
+```bash
+cd /home/aaron/Projects/hexops && pnpm tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/aaron/Projects/hexops && git add src/components/branch-propagate-modal.tsx && git commit -m "feat(branch-prop): add BranchPropagateModal component (#71)"
+```
+
+---
+
+### Task 7: Update `DependabotPanel` to show sync warning + Propagate button
+
+**Files:**
+- Modify: `src/components/detail-sections/dependabot-panel.tsx`
+
+**Context:** The component currently fetches `GET /api/projects/${projectId}/dependabot` on mount. We add a second fetch for `GET /api/projects/${projectId}/branch-sync`. Add the warning banner and Propagate button after the "View on GitHub" header, before the PR list. `BranchPropagateModal` is in `@/components/branch-propagate-modal`.
+
+- [ ] **Step 1: Add imports and `branchSync` state to `DependabotPanel`**
+
+At the top of `dependabot-panel.tsx`, add to imports:
+```typescript
+import { BranchPropagateModal } from '@/components/branch-propagate-modal';
+import { AlertTriangle, GitBranch } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { BranchSyncStatus } from '@/lib/types';
+```
+
+Inside the `DependabotPanel` component, add state after `const [loading, setLoading] = useState(true)`:
+```typescript
+const [outOfSyncBranches, setOutOfSyncBranches] = useState<string[]>([]);
+const [propagateOpen, setPropagateOpen] = useState(false);
+```
+
+- [ ] **Step 2: Add `branch-sync` fetch alongside the existing `dependabot` fetch**
+
+After the existing `useEffect` that fetches dependabot data, add:
+```typescript
+useEffect(() => {
+  fetch(`/api/projects/${projectId}/branch-sync`)
+    .then((r) => r.json())
+    .then((data: { branches?: BranchSyncStatus[] }) => {
+      const oosNames = (data.branches ?? [])
+        .filter((b) => b.status === 'out_of_sync')
+        .map((b) => b.branch);
+      setOutOfSyncBranches(oosNames);
+    })
+    .catch(() => {});
+}, [projectId]);
+```
+
+- [ ] **Step 3: Add the warning banner and modal render inside the component's JSX**
+
+Inside the `return (...)` block, after the `<div className="flex items-center justify-between">` header section (after the "View on GitHub" link `</a>` and before `{config.error && ...}`), add:
+
+```tsx
+{outOfSyncBranches.length > 0 && (
+  <div className="rounded-md bg-amber-500/10 border border-amber-500/20 px-3 py-2 flex items-center justify-between gap-3">
+    <div className="flex items-center gap-2 text-xs text-amber-400">
+      <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+      <span>
+        <strong>{outOfSyncBranches.length}</strong> branch{outOfSyncBranches.length !== 1 ? 'es' : ''} out of sync with main
+        <span className="text-amber-500/70 ml-1">— {outOfSyncBranches.join(', ')}</span>
+      </span>
+    </div>
+    <Button
+      variant="ghost"
+      size="sm"
+      className="h-7 text-xs text-amber-400 hover:text-amber-300 hover:bg-amber-500/10 shrink-0"
+      onClick={() => setPropagateOpen(true)}
+    >
+      <GitBranch className="h-3 w-3 mr-1" />
+      Propagate →
+    </Button>
+  </div>
+)}
+```
+
+At the end of the component's return, before the final closing `</div>`, add:
+```tsx
+<BranchPropagateModal
+  projectId={projectId}
+  open={propagateOpen}
+  onClose={() => setPropagateOpen(false)}
+/>
+```
+
+- [ ] **Step 4: Verify TypeScript**
+
+```bash
+cd /home/aaron/Projects/hexops && pnpm tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/aaron/Projects/hexops && git commit src/components/detail-sections/dependabot-panel.tsx -m "feat(branch-prop): add sync warning banner and propagate button to DependabotPanel (#71)"
+```
+
+---
+
+### Task 8: Push branch and open PR for #71
+
+**Files:** None — git operations only.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+cd /home/aaron/Projects/hexops && git push origin feature/dependabot-integration
+```
+
+- [ ] **Step 2: Open PR via GitHub GraphQL (gh pr edit fails on this repo due to deprecated Projects API)**
+
+The existing PR #67 already covers this branch. Update its title to include #71 using the GraphQL API:
+
+```bash
+cd /home/aaron/Projects/hexops && gh api graphql -f query='
+mutation {
+  updatePullRequest(input: {
+    pullRequestId: "PR_kwDOQ70YMs7TbvMt",
+    title: "feat: Dependabot integration + escalate state + branch propagation (#65, #70, #71)"
+  }) {
+    pullRequest { title }
+  }
+}'
+```
+
+Expected output: `{"data":{"updatePullRequest":{"pullRequest":{"title":"feat: Dependabot integration + escalate state + branch propagation (#65, #70, #71)"}}}}`
+
+- [ ] **Step 3: Verify PR at `https://github.com/Hexaxia-Technologies/hexops/pull/67`**
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec requirement | Task |
+|-----------------|------|
+| `BranchSyncStatus`, `PropagationConfig` types | Task 1 |
+| `propagation` config on `ProjectConfig` | Task 1 |
+| `openPropagationPR` in github-client | Task 2 |
+| `getActiveBranches` | Task 3 |
+| `getBranchSyncStatuses` | Task 3 |
+| `propagateBranch` — PR mode | Task 3 |
+| `propagateBranch` — direct push mode | Task 3 |
+| `propagateBranch` — conflict handling | Task 3 |
+| Worktree cleanup in finally | Task 3 |
+| `GET /api/projects/[id]/branch-sync` | Task 4 |
+| `POST /api/projects/[id]/propagate-branches` | Task 5 |
+| `openPR` override per run | Task 5 |
+| `BranchPropagateModal` — branch selection | Task 6 |
+| `BranchPropagateModal` — mode toggle | Task 6 |
+| `BranchPropagateModal` — live results | Task 6 |
+| `DependabotPanel` — amber warning banner | Task 7 |
+| `DependabotPanel` — Propagate button | Task 7 |
+
+All spec requirements covered. No placeholders detected. Types are consistent across all tasks (`BranchSyncStatus.status` values used identically in Task 3 propagator and Task 6 modal). No monorepo / auto-trigger / history tracking — correctly excluded per spec.

--- a/docs/superpowers/plans/2026-04-21-hexops-escalate-state.md
+++ b/docs/superpowers/plans/2026-04-21-hexops-escalate-state.md
@@ -1,0 +1,1094 @@
+# HexOps Escalate State Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a third patch state — Escalate — for `fixAvailable: false` vulnerabilities, with three resolution options: Force Override, Force Major Bump, and Accept Risk.
+
+**Architecture:** New `escalations.json` store in `.hexops/patches/`, a new API route for escalation CRUD, scanner integration to suppress/annotate escalated vulns, and a modal component on the patches page. No test framework exists — TypeScript compilation + biome lint serve as type-level verification; UI steps include manual acceptance criteria.
+
+**Tech Stack:** Next.js App Router, TypeScript, React, Biome (lint), existing `patch-scanner.ts` / `patch-storage.ts` patterns.
+
+**Spec:** `docs/superpowers/specs/2026-04-21-hexops-escalate-state-design.md`
+**Issue:** #70
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/lib/types.ts` | Modify | Add `EscalateRecord`, `EscalationConfig`, extend `ProjectConfig` and `PatchQueueItem` |
+| `src/lib/escalation-store.ts` | Create | CRUD for `.hexops/patches/escalations.json` |
+| `src/app/api/projects/[id]/escalate/route.ts` | Create | POST (create + execute) and DELETE (reverse) handlers |
+| `src/lib/patch-scanner.ts` | Modify | Suppress/annotate queue items based on escalation records |
+| `src/components/escalate-modal.tsx` | Create | Modal with 3 options + Oh Shit button |
+| `src/components/accepted-risk-panel.tsx` | Create | Per-project collapsible panel for accepted-risk records |
+| `src/app/patches/page.tsx` | Modify | Escalate button on rows, wire modal, accepted-risk panel, major-bump banner |
+
+---
+
+## Task 1: Add Types
+
+**Files:**
+- Modify: `src/lib/types.ts`
+
+- [ ] **Step 1: Add `EscalationConfig` and `EscalateRecord` to types.ts**
+
+Open `src/lib/types.ts` and add after the `DependabotConfig` block (after line 156):
+
+```typescript
+// Escalation Types
+
+export type EscalateAction = 'force_override' | 'force_major' | 'accepted_risk'
+
+export interface EscalationConfig {
+  acceptedRiskMaxDays: number   // default 90
+  autoCommit: boolean           // force_override: commit after patching
+  autoPush: boolean             // force_override: push after committing
+}
+
+export interface EscalateRecord {
+  id: string                    // uuid (crypto.randomUUID())
+  projectId: string
+  package: string
+  action: EscalateAction
+  reason: string
+  createdAt: string             // ISO 8601
+  expiresAt?: string            // accepted_risk only
+  resolvedAt?: string           // set by scanner when upstream patch becomes available
+  overrideVersion?: string      // force_override: version pinned to
+  targetVersion?: string        // force_major: target version
+}
+
+export interface EscalationStore {
+  records: EscalateRecord[]
+}
+```
+
+- [ ] **Step 2: Add `escalation` to `ProjectConfig`**
+
+In `src/lib/types.ts`, find the `ProjectConfig` interface (line 1) and add after `holds?: string[]`:
+
+```typescript
+  escalation?: Partial<EscalationConfig>
+```
+
+- [ ] **Step 3: Add escalation annotation fields to `PatchQueueItem`**
+
+In `src/lib/types.ts`, find `PatchQueueItem` (line 164) and add after `advisoryId?: number`:
+
+```typescript
+  // Escalation state (set by scanner when an EscalateRecord exists for this package)
+  escalationId?: string
+  escalationStatus?: 'accepted_risk' | 'accepted_risk_expired' | 'force_override_pending' | 'force_major_pending'
+  escalationReason?: string
+  escalationExpiresAt?: string
+```
+
+- [ ] **Step 4: Verify types compile**
+
+```bash
+cd /home/aaron/Projects/hexops && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: no output (no errors). If errors appear, fix before continuing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/aaron/Projects/hexops && git add src/lib/types.ts && git commit -m "feat(escalate): add EscalateRecord, EscalationConfig types + PatchQueueItem annotations"
+```
+
+---
+
+## Task 2: Escalation Store
+
+**Files:**
+- Create: `src/lib/escalation-store.ts`
+
+- [ ] **Step 1: Create the store file**
+
+Create `src/lib/escalation-store.ts`:
+
+```typescript
+import fs from 'fs'
+import path from 'path'
+import type { EscalateRecord, EscalationStore } from './types'
+
+const ESCALATIONS_PATH = path.join(process.cwd(), '.hexops', 'patches', 'escalations.json')
+
+function readStore(): EscalationStore {
+  if (!fs.existsSync(ESCALATIONS_PATH)) {
+    return { records: [] }
+  }
+  try {
+    return JSON.parse(fs.readFileSync(ESCALATIONS_PATH, 'utf-8')) as EscalationStore
+  } catch {
+    return { records: [] }
+  }
+}
+
+function writeStore(store: EscalationStore): void {
+  fs.mkdirSync(path.dirname(ESCALATIONS_PATH), { recursive: true })
+  fs.writeFileSync(ESCALATIONS_PATH, JSON.stringify(store, null, 2))
+}
+
+export function getAllEscalations(): EscalateRecord[] {
+  return readStore().records
+}
+
+export function getEscalationsForProject(projectId: string): EscalateRecord[] {
+  return readStore().records.filter(r => r.projectId === projectId)
+}
+
+export function addEscalation(record: EscalateRecord): void {
+  const store = readStore()
+  // Remove any existing record for same project+package (one active record per package per project)
+  store.records = store.records.filter(
+    r => !(r.projectId === record.projectId && r.package === record.package && !r.resolvedAt)
+  )
+  store.records.push(record)
+  writeStore(store)
+}
+
+export function removeEscalation(id: string): boolean {
+  const store = readStore()
+  const before = store.records.length
+  store.records = store.records.filter(r => r.id !== id)
+  if (store.records.length === before) return false
+  writeStore(store)
+  return true
+}
+
+export function resolveEscalation(id: string): void {
+  const store = readStore()
+  const record = store.records.find(r => r.id === id)
+  if (record) {
+    record.resolvedAt = new Date().toISOString()
+    writeStore(store)
+  }
+}
+
+export function getEscalationConfig(projectConfig: { escalation?: { acceptedRiskMaxDays?: number; autoCommit?: boolean; autoPush?: boolean } }): {
+  acceptedRiskMaxDays: number
+  autoCommit: boolean
+  autoPush: boolean
+} {
+  return {
+    acceptedRiskMaxDays: projectConfig.escalation?.acceptedRiskMaxDays ?? 90,
+    autoCommit: projectConfig.escalation?.autoCommit ?? false,
+    autoPush: projectConfig.escalation?.autoPush ?? false,
+  }
+}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+```bash
+cd /home/aaron/Projects/hexops && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/aaron/Projects/hexops && git add src/lib/escalation-store.ts && git commit -m "feat(escalate): add escalation-store (CRUD for escalations.json)"
+```
+
+---
+
+## Task 3: POST Escalation API Route
+
+**Files:**
+- Create: `src/app/api/projects/[id]/escalate/route.ts`
+
+Look at `src/app/api/projects/[id]/update/route.ts` for the pattern used to load project config, run shell commands, commit, and push. Replicate those patterns here.
+
+- [ ] **Step 1: Create the escalate route**
+
+Create `src/app/api/projects/[id]/escalate/route.ts`:
+
+```typescript
+import { NextRequest, NextResponse } from 'next/server'
+import { loadConfig } from '@/lib/config'
+import { addEscalation, getEscalationConfig } from '@/lib/escalation-store'
+import { resolveLockfile } from '@/lib/lockfile-resolver'
+import type { EscalateAction, EscalateRecord } from '@/lib/types'
+import fs from 'fs'
+import path from 'path'
+import { execSync } from 'child_process'
+
+interface EscalateRequestBody {
+  package: string
+  action: EscalateAction
+  reason: string
+  overrideVersion?: string
+  targetVersion?: string
+  expiresAt?: string
+  emergency?: boolean
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const body = (await request.json()) as EscalateRequestBody
+
+  const config = loadConfig()
+  const project = config.projects.find(p => p.id === id)
+  if (!project) {
+    return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+  }
+
+  const { package: pkg, action, reason, overrideVersion, targetVersion, expiresAt, emergency } = body
+
+  if (!pkg || !action || !reason) {
+    return NextResponse.json({ error: 'package, action, and reason are required' }, { status: 400 })
+  }
+
+  const escalationCfg = getEscalationConfig(project)
+
+  const record: EscalateRecord = {
+    id: crypto.randomUUID(),
+    projectId: id,
+    package: pkg,
+    action,
+    reason,
+    createdAt: new Date().toISOString(),
+    ...(overrideVersion && { overrideVersion }),
+    ...(targetVersion && { targetVersion }),
+    ...(expiresAt && { expiresAt }),
+  }
+
+  try {
+    if (action === 'force_override') {
+      if (!overrideVersion) {
+        return NextResponse.json({ error: 'overrideVersion required for force_override' }, { status: 400 })
+      }
+      // Inject override into package.json
+      const pkgJsonPath = path.join(project.path, 'package.json')
+      const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'))
+      pkgJson.overrides = { ...pkgJson.overrides, [pkg]: overrideVersion }
+      if (pkgJson.pnpm) {
+        pkgJson.pnpm.overrides = { ...pkgJson.pnpm?.overrides, [pkg]: overrideVersion }
+      }
+      fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n')
+
+      // Regenerate lockfile
+      const lockfileResult = await resolveLockfile(project.path, 'repair')
+      if (!lockfileResult.success) {
+        // Revert package.json change
+        execSync('git checkout -- package.json', { cwd: project.path })
+        return NextResponse.json({ error: `Lockfile regeneration failed: ${lockfileResult.error}` }, { status: 500 })
+      }
+
+      const shouldCommit = emergency || escalationCfg.autoCommit
+      const shouldPush = emergency || (escalationCfg.autoCommit && escalationCfg.autoPush)
+
+      if (shouldCommit) {
+        execSync(`git add package.json ${lockfileResult.lockfileName ?? ''}`, { cwd: project.path })
+        execSync(`git commit -m "fix(deps): force override ${pkg}@${overrideVersion} — ${reason}"`, { cwd: project.path })
+      }
+      if (shouldPush) {
+        execSync('git push', { cwd: project.path })
+      }
+
+      record.overrideVersion = overrideVersion
+    }
+
+    if (action === 'force_major') {
+      if (!targetVersion) {
+        return NextResponse.json({ error: 'targetVersion required for force_major' }, { status: 400 })
+      }
+      // Update package.json dep version only — never auto-commit
+      const pkgJsonPath = path.join(project.path, 'package.json')
+      const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'))
+      for (const depSection of ['dependencies', 'devDependencies', 'peerDependencies'] as const) {
+        if (pkgJson[depSection]?.[pkg]) {
+          pkgJson[depSection][pkg] = `^${targetVersion}`
+          break
+        }
+      }
+      fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n')
+      // Do NOT commit — leave dirty for human review
+    }
+
+    if (action === 'accepted_risk') {
+      // Validate expiry
+      if (expiresAt) {
+        const maxDate = new Date()
+        maxDate.setDate(maxDate.getDate() + escalationCfg.acceptedRiskMaxDays)
+        if (new Date(expiresAt) > maxDate) {
+          record.expiresAt = maxDate.toISOString()
+        }
+      }
+      // No file changes — just record
+    }
+
+    addEscalation(record)
+    return NextResponse.json({ success: true, record })
+  } catch (err) {
+    return NextResponse.json({ error: String(err) }, { status: 500 })
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const { escalationId } = await request.json() as { escalationId: string }
+
+  if (!escalationId) {
+    return NextResponse.json({ error: 'escalationId required' }, { status: 400 })
+  }
+
+  const removed = removeEscalation(escalationId)
+  if (!removed) {
+    return NextResponse.json({ error: 'Escalation not found' }, { status: 404 })
+  }
+
+  return NextResponse.json({ success: true })
+}
+```
+
+- [ ] **Step 2: Fix the missing import**
+
+The DELETE handler uses `removeEscalation` but it wasn't imported. Add it to the import line at the top:
+
+```typescript
+import { addEscalation, removeEscalation, getEscalationConfig } from '@/lib/escalation-store'
+```
+
+- [ ] **Step 3: Check what `resolveLockfile` actually exports**
+
+```bash
+grep -n "export" /home/aaron/Projects/hexops/src/lib/lockfile-resolver.ts | head -10
+```
+
+Adjust the import and call signature to match whatever `lockfile-resolver.ts` actually exports. The function name and return shape may differ — check before assuming.
+
+- [ ] **Step 4: Verify compilation**
+
+```bash
+cd /home/aaron/Projects/hexops && npx tsc --noEmit 2>&1 | head -30
+```
+
+Expected: no errors. Fix any type mismatches before continuing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/aaron/Projects/hexops && git add src/app/api/projects/[id]/escalate/route.ts && git commit -m "feat(escalate): add POST/DELETE escalate API route"
+```
+
+---
+
+## Task 4: Scanner Integration
+
+**Files:**
+- Modify: `src/lib/patch-scanner.ts`
+
+- [ ] **Step 1: Find where PatchQueueItems are finalized in patch-scanner.ts**
+
+```bash
+grep -n "PatchQueueItem\|fixAvailable\|priority" /home/aaron/Projects/hexops/src/lib/patch-scanner.ts | head -20
+```
+
+Identify the function that builds and returns the final `PatchQueueItem[]` array. This is where we'll inject escalation annotations.
+
+- [ ] **Step 2: Add escalation annotation function**
+
+In `src/lib/patch-scanner.ts`, add this import at the top:
+
+```typescript
+import { getAllEscalations } from './escalation-store'
+import type { EscalateRecord } from './types'
+```
+
+Then add this helper function before the main scanner export:
+
+```typescript
+function annotateWithEscalations(items: PatchQueueItem[]): PatchQueueItem[] {
+  const escalations = getAllEscalations()
+  const now = new Date()
+
+  return items.map(item => {
+    const record = escalations.find(
+      r => r.projectId === item.projectId && r.package === item.package && !r.resolvedAt
+    )
+    if (!record) return item
+
+    // Check if upstream now provides a fix — auto-resolve
+    if (item.fixAvailable && record.action !== 'accepted_risk') {
+      // Scanner found a fix — mark resolved (fire-and-forget, don't block)
+      import('./escalation-store').then(({ resolveEscalation }) => resolveEscalation(record.id))
+      return item // re-surface as normal patchable
+    }
+
+    const base = {
+      ...item,
+      escalationId: record.id,
+      escalationReason: record.reason,
+    }
+
+    if (record.action === 'accepted_risk') {
+      const expired = record.expiresAt ? new Date(record.expiresAt) < now : false
+      return {
+        ...base,
+        escalationStatus: expired ? 'accepted_risk_expired' as const : 'accepted_risk' as const,
+        escalationExpiresAt: record.expiresAt,
+      }
+    }
+
+    if (record.action === 'force_override') {
+      return { ...base, escalationStatus: 'force_override_pending' as const }
+    }
+
+    if (record.action === 'force_major') {
+      return { ...base, escalationStatus: 'force_major_pending' as const }
+    }
+
+    return item
+  })
+}
+```
+
+- [ ] **Step 3: Call annotateWithEscalations in the scanner**
+
+Find the return statement of the function that builds `PatchQueueItem[]` (identified in Step 1). Wrap the returned array:
+
+```typescript
+// Before:
+return items
+
+// After:
+return annotateWithEscalations(items)
+```
+
+- [ ] **Step 4: Filter out non-expired accepted_risk items from the active queue**
+
+In the same function, after `annotateWithEscalations`, filter:
+
+```typescript
+return annotateWithEscalations(items).filter(
+  item => item.escalationStatus !== 'accepted_risk'
+)
+```
+
+Note: `accepted_risk_expired` items are NOT filtered — they re-surface with the expired badge.
+
+- [ ] **Step 5: Verify compilation**
+
+```bash
+cd /home/aaron/Projects/hexops && npx tsc --noEmit 2>&1 | head -30
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/aaron/Projects/hexops && git add src/lib/patch-scanner.ts && git commit -m "feat(escalate): annotate patch queue items with escalation state"
+```
+
+---
+
+## Task 5: EscalateModal Component
+
+**Files:**
+- Create: `src/components/escalate-modal.tsx`
+
+- [ ] **Step 1: Check existing modal/dialog patterns in the codebase**
+
+```bash
+grep -rn "Dialog\|Modal" /home/aaron/Projects/hexops/src/components/ --include="*.tsx" -l | head -5
+```
+
+Open one of those files to understand which Dialog component is used (likely Radix UI `@radix-ui/react-dialog` via shadcn). Replicate the import pattern.
+
+- [ ] **Step 2: Create EscalateModal**
+
+Create `src/components/escalate-modal.tsx`:
+
+```typescript
+'use client'
+
+import { useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { Input } from '@/components/ui/input'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { Switch } from '@/components/ui/switch'
+import { AlertTriangle, Zap } from 'lucide-react'
+import type { PatchQueueItem, EscalateAction } from '@/lib/types'
+
+interface EscalateModalProps {
+  open: boolean
+  item: PatchQueueItem | null
+  projectEscalationConfig?: {
+    acceptedRiskMaxDays?: number
+    autoCommit?: boolean
+    autoPush?: boolean
+  }
+  onClose: () => void
+  onSuccess: (item: PatchQueueItem) => void
+}
+
+export function EscalateModal({ open, item, projectEscalationConfig, onClose, onSuccess }: EscalateModalProps) {
+  const [action, setAction] = useState<EscalateAction>('force_override')
+  const [reason, setReason] = useState('')
+  const [overrideVersion, setOverrideVersion] = useState(item?.targetVersion ?? '')
+  const [targetVersion, setTargetVersion] = useState(item?.targetVersion ?? '')
+  const [expiresAt, setExpiresAt] = useState('')
+  const [autoCommit, setAutoCommit] = useState(projectEscalationConfig?.autoCommit ?? false)
+  const [autoPush, setAutoPush] = useState(projectEscalationConfig?.autoPush ?? false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const maxDays = projectEscalationConfig?.acceptedRiskMaxDays ?? 90
+  const maxDate = new Date()
+  maxDate.setDate(maxDate.getDate() + maxDays)
+
+  async function submit(emergency = false) {
+    if (!item || !reason.trim()) return
+    setLoading(true)
+    setError(null)
+
+    try {
+      const res = await fetch(`/api/projects/${item.projectId}/escalate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          package: item.package,
+          action,
+          reason: reason.trim(),
+          ...(action === 'force_override' && { overrideVersion, autoCommit, autoPush }),
+          ...(action === 'force_major' && { targetVersion }),
+          ...(action === 'accepted_risk' && expiresAt && { expiresAt }),
+          ...(emergency && { emergency: true }),
+        }),
+      })
+
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error ?? 'Escalation failed')
+
+      onSuccess(item)
+      onClose()
+    } catch (err) {
+      setError(String(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!item) return null
+
+  return (
+    <Dialog open={open} onOpenChange={open => !open && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-amber-500" />
+            Escalate: {item.package}
+          </DialogTitle>
+          {item.url && (
+            <a href={item.url} target="_blank" rel="noopener noreferrer" className="text-xs text-blue-500 hover:underline">
+              View advisory ↗
+            </a>
+          )}
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <RadioGroup value={action} onValueChange={v => setAction(v as EscalateAction)}>
+            {/* Force Override */}
+            <div className={`rounded-lg border p-3 cursor-pointer ${action === 'force_override' ? 'border-blue-500 bg-blue-50 dark:bg-blue-950' : ''}`}
+              onClick={() => setAction('force_override')}>
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="force_override" id="force_override" />
+                <Label htmlFor="force_override" className="font-medium cursor-pointer">Force Override</Label>
+              </div>
+              <p className="text-xs text-muted-foreground mt-1 ml-6">
+                Pin transitive dep via package.json overrides + regenerate lockfile
+              </p>
+              {action === 'force_override' && (
+                <div className="mt-3 ml-6 space-y-3">
+                  <div>
+                    <Label className="text-xs">Pin to version</Label>
+                    <Input
+                      className="mt-1 h-8 text-sm"
+                      value={overrideVersion}
+                      onChange={e => setOverrideVersion(e.target.value)}
+                      placeholder="e.g. 2.17.3"
+                    />
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <Label className="text-xs">Auto-commit</Label>
+                    <Switch checked={autoCommit} onCheckedChange={setAutoCommit} />
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <Label className="text-xs text-muted-foreground">Auto-push (requires auto-commit)</Label>
+                    <Switch checked={autoPush} disabled={!autoCommit} onCheckedChange={setAutoPush} />
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Force Major Bump */}
+            <div className={`rounded-lg border p-3 cursor-pointer ${action === 'force_major' ? 'border-amber-500 bg-amber-50 dark:bg-amber-950' : ''}`}
+              onClick={() => setAction('force_major')}>
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="force_major" id="force_major" />
+                <Label htmlFor="force_major" className="font-medium cursor-pointer">Force Major Bump</Label>
+              </div>
+              <p className="text-xs text-muted-foreground mt-1 ml-6">
+                Updates package.json only. <strong>Never auto-commits.</strong> Review and commit manually.
+              </p>
+              {action === 'force_major' && (
+                <div className="mt-3 ml-6">
+                  <Label className="text-xs">Target version</Label>
+                  <Input
+                    className="mt-1 h-8 text-sm"
+                    value={targetVersion}
+                    onChange={e => setTargetVersion(e.target.value)}
+                    placeholder="e.g. 4.0.0"
+                  />
+                  <p className="text-xs text-amber-600 mt-2">
+                    ⚠ Breaking changes likely. Test thoroughly before merging.
+                  </p>
+                </div>
+              )}
+            </div>
+
+            {/* Accept Risk */}
+            <div className={`rounded-lg border p-3 cursor-pointer ${action === 'accepted_risk' ? 'border-orange-500 bg-orange-50 dark:bg-orange-950' : ''}`}
+              onClick={() => setAction('accepted_risk')}>
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="accepted_risk" id="accepted_risk" />
+                <Label htmlFor="accepted_risk" className="font-medium cursor-pointer">Accept Risk</Label>
+              </div>
+              <p className="text-xs text-muted-foreground mt-1 ml-6">
+                Suppress this vuln from the queue. Max {maxDays} days. Will re-surface on expiry.
+              </p>
+              {action === 'accepted_risk' && (
+                <div className="mt-3 ml-6 space-y-2">
+                  <Label className="text-xs">Expiry date (max {maxDate.toLocaleDateString()})</Label>
+                  <Input
+                    type="date"
+                    className="h-8 text-sm"
+                    max={maxDate.toISOString().split('T')[0]}
+                    value={expiresAt ? expiresAt.split('T')[0] : ''}
+                    onChange={e => setExpiresAt(e.target.value ? new Date(e.target.value).toISOString() : '')}
+                  />
+                </div>
+              )}
+            </div>
+          </RadioGroup>
+
+          {/* Reason — always required */}
+          <div>
+            <Label className="text-sm">Reason <span className="text-red-500">*</span></Label>
+            <Textarea
+              className="mt-1 text-sm"
+              rows={2}
+              placeholder="Why is this being escalated rather than patched normally?"
+              value={reason}
+              onChange={e => setReason(e.target.value)}
+            />
+          </div>
+
+          {error && (
+            <p className="text-xs text-red-500 bg-red-50 dark:bg-red-950 rounded p-2">{error}</p>
+          )}
+        </div>
+
+        <DialogFooter className="flex items-center justify-between">
+          <div>
+            {action === 'force_override' && (
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={!reason.trim() || !overrideVersion || loading}
+                onClick={() => submit(true)}
+                className="gap-1"
+              >
+                <Zap className="h-3 w-3" />
+                Patch Now
+              </Button>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={onClose} disabled={loading}>
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              disabled={!reason.trim() || loading}
+              onClick={() => submit(false)}
+            >
+              {loading ? 'Working…' : 'Escalate'}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+```
+
+- [ ] **Step 3: Verify imports exist**
+
+```bash
+grep -r "RadioGroup\|RadioGroupItem" /home/aaron/Projects/hexops/src/components/ui/ -l 2>/dev/null
+```
+
+If `radio-group` doesn't exist in `src/components/ui/`, install it:
+
+```bash
+cd /home/aaron/Projects/hexops && npx shadcn@latest add radio-group
+```
+
+- [ ] **Step 4: Verify compilation**
+
+```bash
+cd /home/aaron/Projects/hexops && npx tsc --noEmit 2>&1 | head -30
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/aaron/Projects/hexops && git add src/components/escalate-modal.tsx && git commit -m "feat(escalate): add EscalateModal component with 3 options + Patch Now button"
+```
+
+---
+
+## Task 6: AcceptedRiskPanel Component
+
+**Files:**
+- Create: `src/components/accepted-risk-panel.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `src/components/accepted-risk-panel.tsx`:
+
+```typescript
+'use client'
+
+import { useState } from 'react'
+import { ChevronDown, ChevronRight, Clock, AlertTriangle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import type { PatchQueueItem } from '@/lib/types'
+
+interface AcceptedRiskPanelProps {
+  projectId: string
+  projectName: string
+  items: PatchQueueItem[]   // items where escalationStatus === 'accepted_risk' or 'accepted_risk_expired'
+  onReverse: (item: PatchQueueItem) => void
+}
+
+export function AcceptedRiskPanel({ projectId, projectName, items, onReverse }: AcceptedRiskPanelProps) {
+  const [expanded, setExpanded] = useState(false)
+  const [reversing, setReversing] = useState<string | null>(null)
+
+  if (items.length === 0) return null
+
+  const expired = items.filter(i => i.escalationStatus === 'accepted_risk_expired')
+  const active = items.filter(i => i.escalationStatus === 'accepted_risk')
+
+  async function handleReverse(item: PatchQueueItem) {
+    if (!item.escalationId) return
+    setReversing(item.escalationId)
+    try {
+      await fetch(`/api/projects/${item.projectId}/escalate`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ escalationId: item.escalationId }),
+      })
+      onReverse(item)
+    } finally {
+      setReversing(null)
+    }
+  }
+
+  function daysUntilExpiry(expiresAt: string) {
+    const diff = new Date(expiresAt).getTime() - Date.now()
+    return Math.ceil(diff / (1000 * 60 * 60 * 24))
+  }
+
+  return (
+    <div className="mt-2 rounded-lg border border-orange-200 dark:border-orange-900 bg-orange-50/50 dark:bg-orange-950/20">
+      <button
+        className="w-full flex items-center gap-2 px-3 py-2 text-sm font-medium text-orange-700 dark:text-orange-400"
+        onClick={() => setExpanded(e => !e)}
+      >
+        {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        Accepted Risk ({items.length})
+        {expired.length > 0 && (
+          <Badge variant="destructive" className="ml-1 text-xs h-4">
+            {expired.length} expired
+          </Badge>
+        )}
+      </button>
+
+      {expanded && (
+        <div className="px-3 pb-3 space-y-2">
+          {/* Expired items first */}
+          {[...expired, ...active].map(item => {
+            const isExpired = item.escalationStatus === 'accepted_risk_expired'
+            const days = item.escalationExpiresAt ? daysUntilExpiry(item.escalationExpiresAt) : null
+
+            return (
+              <div
+                key={item.escalationId}
+                className={`flex items-start justify-between gap-3 rounded p-2 text-sm ${
+                  isExpired ? 'bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800' : 'bg-white dark:bg-gray-900/50'
+                }`}
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="font-mono text-xs font-medium">{item.package}</span>
+                    {isExpired && (
+                      <Badge variant="destructive" className="text-xs h-4">Expired</Badge>
+                    )}
+                    {!isExpired && days !== null && (
+                      <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                        <Clock className="h-3 w-3" />
+                        Expires in {days}d
+                      </span>
+                    )}
+                  </div>
+                  {item.escalationReason && (
+                    <p className="text-xs text-muted-foreground mt-0.5 truncate">{item.escalationReason}</p>
+                  )}
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 text-xs shrink-0"
+                  disabled={reversing === item.escalationId}
+                  onClick={() => handleReverse(item)}
+                >
+                  {reversing === item.escalationId ? '…' : 'Reverse'}
+                </Button>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+```bash
+cd /home/aaron/Projects/hexops && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/aaron/Projects/hexops && git add src/components/accepted-risk-panel.tsx && git commit -m "feat(escalate): add AcceptedRiskPanel component"
+```
+
+---
+
+## Task 7: Wire Into Patches Page
+
+**Files:**
+- Modify: `src/app/patches/page.tsx`
+
+- [ ] **Step 1: Add imports to patches/page.tsx**
+
+At the top of `src/app/patches/page.tsx`, add:
+
+```typescript
+import { EscalateModal } from '@/components/escalate-modal'
+import { AcceptedRiskPanel } from '@/components/accepted-risk-panel'
+```
+
+- [ ] **Step 2: Add escalate modal state**
+
+Inside the `PatchesPage` component, add state variables alongside the existing state:
+
+```typescript
+const [escalateItem, setEscalateItem] = useState<PatchQueueItem | null>(null)
+const [escalateModalOpen, setEscalateModalOpen] = useState(false)
+```
+
+- [ ] **Step 3: Add Escalate button to patch rows**
+
+Find where individual patch rows are rendered (look for `PatchRow` or the row JSX rendering `item.package`). On rows where `item.fixAvailable === false` and no active non-expired escalation:
+
+```typescript
+{item.fixAvailable === false && !item.escalationId && (
+  <Button
+    variant="outline"
+    size="sm"
+    className="h-6 text-xs"
+    onClick={() => {
+      setEscalateItem(item)
+      setEscalateModalOpen(true)
+    }}
+  >
+    Escalate
+  </Button>
+)}
+```
+
+- [ ] **Step 4: Add Pending Major Bump banner**
+
+In the grouped-by-project view, before or after the project's patch list, add:
+
+```typescript
+{/* Major bump pending banner */}
+{projectItems.some(i => i.escalationStatus === 'force_major_pending') && (
+  <div className="flex items-center gap-2 rounded-md border border-amber-300 bg-amber-50 dark:bg-amber-950/30 px-3 py-2 text-sm text-amber-700 dark:text-amber-400 mb-2">
+    <AlertTriangle className="h-4 w-4 shrink-0" />
+    <span>
+      Major bump pending for{' '}
+      <strong>
+        {projectItems.filter(i => i.escalationStatus === 'force_major_pending').map(i => i.package).join(', ')}
+      </strong>
+      . Review package.json and commit manually.
+    </span>
+  </div>
+)}
+```
+
+- [ ] **Step 5: Add AcceptedRiskPanel below each project's patch list**
+
+In the grouped-by-project view, after the patch list for each project:
+
+```typescript
+<AcceptedRiskPanel
+  projectId={projectId}
+  projectName={projectName}
+  items={projectItems.filter(i =>
+    i.escalationStatus === 'accepted_risk' || i.escalationStatus === 'accepted_risk_expired'
+  )}
+  onReverse={() => {
+    // Trigger a re-scan to refresh the queue
+    handleRefresh()
+  }}
+/>
+```
+
+Where `handleRefresh()` is whatever function the page uses to re-fetch patch data. Find the existing pattern and replicate it.
+
+- [ ] **Step 6: Render EscalateModal**
+
+Somewhere in the page JSX (near other modals/dialogs if any exist):
+
+```typescript
+<EscalateModal
+  open={escalateModalOpen}
+  item={escalateItem}
+  projectEscalationConfig={
+    escalateItem
+      ? config.projects.find(p => p.id === escalateItem.projectId)?.escalation
+      : undefined
+  }
+  onClose={() => {
+    setEscalateModalOpen(false)
+    setEscalateItem(null)
+  }}
+  onSuccess={() => {
+    setEscalateModalOpen(false)
+    setEscalateItem(null)
+    handleRefresh()
+  }}
+/>
+```
+
+Note: `config` here refers to however the page accesses `hexops.config.json`. Check what the page currently does to load project config and replicate it. It may already be in a React context or fetched separately.
+
+- [ ] **Step 7: Verify compilation and lint**
+
+```bash
+cd /home/aaron/Projects/hexops && npx tsc --noEmit 2>&1 | head -30
+npm run lint 2>&1 | head -20
+```
+
+Expected: no errors.
+
+- [ ] **Step 8: Manual UI verification**
+
+Start the dev server:
+
+```bash
+cd /home/aaron/Projects/hexops && npm run dev
+```
+
+Open `http://localhost:3000/patches` and verify:
+
+1. A `fixAvailable: false` row shows an "Escalate" button (may need to find a project with an unfixable vuln, or temporarily set `fixAvailable: false` on a test item)
+2. Clicking Escalate opens the modal with 3 radio options
+3. Force Override shows version input + auto-commit/push toggles + "Patch Now" button
+4. Force Major Bump shows target version + breaking-changes warning, no auto-commit options
+5. Accept Risk shows expiry date picker capped at project max
+6. Reason field is required — submit is disabled when empty
+7. After escalation, the row disappears from the queue (accepted_risk) or gets annotated (force_major_pending)
+8. Accepted Risk panel appears below the project with the suppressed item
+9. Reverse button removes the record and the item re-appears in the queue
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /home/aaron/Projects/hexops && git add src/app/patches/page.tsx && git commit -m "feat(escalate): wire EscalateModal, AcceptedRiskPanel, and major-bump banner into patches page"
+```
+
+---
+
+## Task 8: Push and Open PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+cd /home/aaron/Projects/hexops && git push -u origin feature/dependabot-integration
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create \
+  --repo Hexaxia-Technologies/hexops \
+  --title "feat: escalate state for unfixable vulnerabilities (#70)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds **Escalate** as a third patch state for `fixAvailable: false` vulnerabilities
+- Three resolution options: Force Override (pin transitive dep via overrides), Force Major Bump (manual review required), Accept Risk (suppress with expiry)
+- **"Patch Now"** emergency button on Force Override — commits and pushes immediately regardless of project config
+- Per-project escalation config in `hexops.config.json` (max risk days, auto-commit, auto-push)
+- Scanner suppresses accepted-risk items, re-surfaces on expiry or when upstream patch ships
+- Accepted Risk panel per project shows active suppressions with countdown and Reverse button
+
+## Test plan
+- [ ] Escalate button appears on `fixAvailable: false` rows including Dependabot-managed projects
+- [ ] All three modal options render and submit correctly
+- [ ] Force Major Bump never auto-commits
+- [ ] Patch Now (emergency) commits + pushes immediately
+- [ ] Accepted-risk items disappear from queue, appear in panel
+- [ ] Expired items re-surface with Expired badge
+- [ ] Reverse removes record and re-surfaces vuln
+
+Closes #70
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-04-21-hexops-branch-propagation-design.md
+++ b/docs/superpowers/specs/2026-04-21-hexops-branch-propagation-design.md
@@ -1,0 +1,205 @@
+# HexOps Branch Propagation — Design Spec
+
+**Date:** 2026-04-21
+**Issue:** #71
+**Status:** Approved — pending implementation plan
+
+---
+
+## Problem
+
+Dependabot targets one branch (typically `main`). After a Dependabot PR merges, active feature/dev branches remain on the old dependency versions indefinitely. HexOps reports patching complete based on `main`, but other branches are still exposed.
+
+When `package.json` is later manually synced between branches, `overrides` config changes cause lockfile mismatches (`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`) that break Vercel/CI deploys.
+
+---
+
+## Solution Overview
+
+Three moving parts:
+
+1. **Detection** (automatic, scan-time) — compare `package.json` on each active remote branch against `main`, surface out-of-sync branches as a warning in the Dependabot panel.
+2. **Propagation** (manual trigger) — user selects branches, HexOps syncs `package.json` from main, regenerates the lockfile, then opens a PR or pushes directly per project config.
+3. **Frontend** — warning banner + Propagate button inside the existing `DependabotPanel`. New `<BranchPropagateModal>` component handles branch selection and shows live results.
+
+---
+
+## Data Model
+
+### Type additions — `types.ts`
+
+```typescript
+interface BranchSyncStatus {
+  branch: string;
+  status: 'synced' | 'out_of_sync' | 'conflict' | 'propagated';
+  prUrl?: string;        // set when openPR mode and PR was created
+  error?: string;        // set when status is 'conflict'
+}
+
+interface PropagationConfig {
+  activeBranchDays: number;   // default: 30
+  openPR: boolean;            // default: true
+  autoPush: boolean;          // default: false — only relevant when openPR: false
+}
+```
+
+### `PatchSummary` additions
+
+```typescript
+// Added to existing PatchSummary per-project summary (or ProjectScanResult):
+branchesOutOfSync?: string[]   // branch names behind main on package.json deps
+```
+
+### Per-project config additions — `hexops.config.json`
+
+```json
+{
+  "projects": {
+    "my-project": {
+      "propagation": {
+        "activeBranchDays": 30,
+        "openPR": true,
+        "autoPush": false
+      }
+    }
+  }
+}
+```
+
+- `activeBranchDays` — branches with no commit in this window are skipped. Default: 30.
+- `openPR` — when `true`, creates a GitHub PR from a `hexops/sync-{branch}-{timestamp}` branch targeting the downstream branch. When `false`, pushes directly to the branch.
+- `autoPush` — only used when `openPR: false`. Default: false (direct push requires explicit confirmation in modal).
+
+---
+
+## Backend
+
+### New lib: `src/lib/branch-propagator.ts`
+
+Owns all branch sync logic, keeping route handlers thin.
+
+**Exports:**
+
+`getActiveBranches(projectPath, days): Promise<string[]>`
+- Runs `git fetch origin` then `git for-each-ref refs/remotes/origin/` filtered by committer date within `days`
+- Excludes `main`, `master`, `HEAD`
+
+`getBranchSyncStatuses(projectPath, activeBranches): Promise<BranchSyncStatus[]>`
+- For each branch, compares `dependencies`, `devDependencies`, and `overrides` from `git show origin/{branch}:package.json` against `git show origin/main:package.json`
+- Returns status `'synced'` or `'out_of_sync'` per branch
+- Runs branch reads in parallel
+
+`propagateBranch(projectPath, branch, config, token): Promise<BranchSyncStatus>`
+- Creates a temp git worktree at `/tmp/hexops-propagate-{branch}-{timestamp}`
+- Checks out the target branch in the worktree
+- Runs `git checkout origin/main -- package.json`
+- Runs `pnpm/npm/yarn install --no-frozen-lockfile` (PM detected via `detectPackageManager`)
+- If `config.openPR`:
+  - Commits to `hexops/sync-{branch}-{timestamp}` branch
+  - Pushes to origin
+  - Opens PR via GitHub API targeting `branch`
+  - Returns status `'propagated'` with `prUrl`
+- If `!config.openPR`:
+  - Commits and pushes directly to `branch`
+  - Returns status `'propagated'`
+- On `package.json` merge conflict: returns status `'conflict'` with error message
+- Always cleans up worktree in a `finally` block
+
+`openPropagationPR(owner, repo, head, base, token): Promise<string>` (in `github-client.ts`)
+- Creates a PR via GitHub API, returns the PR URL
+
+### New API Routes
+
+**`GET /api/projects/[id]/branch-sync`**
+
+Returns current sync status for all active branches. Called when opening the propagate modal.
+
+Response:
+```typescript
+{
+  branches: BranchSyncStatus[]
+  config: PropagationConfig
+}
+```
+
+**`POST /api/projects/[id]/propagate-branches`**
+
+Executes propagation for selected branches.
+
+Request:
+```typescript
+{
+  branches: string[]
+  openPR?: boolean   // overrides project config for this run
+}
+```
+
+Response:
+```typescript
+{
+  results: BranchSyncStatus[]
+  skipped: string[]   // branches that were already in sync
+}
+```
+
+### Scanner Integration — `patch-scanner.ts`
+
+After building `PatchQueueItem[]` for a Dependabot-managed project, call `getBranchSyncStatuses()` and attach the list of out-of-sync branch names to the project's summary entry.
+
+- Only runs for Dependabot-managed projects (skip others — no value, extra cost)
+- Runs regardless of GitHub token (branch comparison is local git only — no API calls at scan time)
+- Failures in branch detection are non-fatal — log and continue, don't block the scan
+
+---
+
+## Frontend
+
+### `DependabotPanel` additions
+
+When `branchesOutOfSync` is non-empty, show an amber warning banner inside the panel:
+
+```
+⚠ 2 branches out of sync with main — dev, feature/auth    [Propagate →]
+```
+
+Clicking "Propagate →" opens `<BranchPropagateModal>`.
+
+### `<BranchPropagateModal>` — New Standalone Component
+
+**On open:** calls `GET /api/projects/[id]/branch-sync` to get current statuses (may have changed since scan).
+
+**Structure:**
+- Branch list with checkboxes (out-of-sync branches checked by default, synced branches shown greyed/unchecked)
+- Mode toggle: "Open PR" / "Push directly" — reflects `propagation.openPR` project config default
+- Submit button: "Propagate Selected"
+- After submit: inline per-branch results replace the checkboxes
+  - ✅ PR opened — [link]
+  - ✅ Pushed to branch
+  - ⚠ Conflict — manual sync needed: `{error message}`
+
+---
+
+## Error Handling
+
+- **No GitHub token + openPR mode** — block submit in modal, show "GitHub token required for PR mode — add token in Settings"
+- **`package.json` merge conflict** — mark that branch as `conflict` in results, continue with remaining branches. Do not abort the whole run.
+- **Lockfile regen failure** — mark branch as `conflict` with error, revert `package.json` change in the worktree before cleanup
+- **Branch already in sync** — skip silently, include in `skipped` response field
+- **Worktree cleanup failure** — log error, do not surface to user (non-fatal)
+
+---
+
+## What This Does Not Cover
+
+- Monorepo nested `package.json` files (only root manifest synced)
+- Auto-triggering propagation without user confirmation
+- Tracking historical propagation runs
+- Non-Dependabot-managed projects (branch sync only surfaces for managed projects)
+
+---
+
+## Related Issues
+
+- #71 — This feature
+- #70 — Escalate state (separate PR, implemented)
+- #65 — Dependabot integration (precursor, implemented in PR #67)

--- a/docs/superpowers/specs/2026-04-21-hexops-escalate-state-design.md
+++ b/docs/superpowers/specs/2026-04-21-hexops-escalate-state-design.md
@@ -1,0 +1,190 @@
+# HexOps Escalate State — Design Spec
+
+**Date:** 2026-04-21
+**Issue:** #70
+**PR:** Separate from #71 (branch propagation)
+**Status:** Approved — pending implementation plan
+
+---
+
+## Problem
+
+When Dependabot marks a vulnerability as `fixAvailable: false`, HexOps has no action path. The vuln sits flagged indefinitely with no resolution options. Additionally, Dependabot-managed projects currently disable all manual patching in the UI — meaning even emergency overrides are blocked.
+
+This creates a binary: auto-patch or do nothing. We need a third state: **Escalate**.
+
+---
+
+## Solution Overview
+
+Add an Escalate flow triggered on any `fixAvailable: false` vulnerability row. Three actions are available:
+
+| Action | What it does | Auto-commit/push |
+|--------|-------------|------------------|
+| Force Override | Pins transitive dep via `overrides`/`resolutions` in package.json + regenerates lockfile | Configurable per project (or immediate via "Oh Shit" button) |
+| Force Major Bump | Updates dep version in package.json only | Never — always manual review |
+| Accept Risk | Records reason + expiry, suppresses vuln from queue | No file changes |
+
+---
+
+## Data Model
+
+### `EscalateRecord` — `.hexops/patches/escalations.json`
+
+```typescript
+interface EscalateRecord {
+  id: string                    // uuid
+  projectId: string
+  package: string
+  action: 'force_override' | 'force_major' | 'accepted_risk'
+  reason: string
+  createdAt: string             // ISO 8601
+  expiresAt?: string            // accepted_risk only — enforced max from project config
+  resolvedAt?: string           // set by scanner when upstream patch ships
+  overrideVersion?: string      // force_override: version pinned to
+  targetVersion?: string        // force_major: target version
+}
+```
+
+`escalations.json` is a flat array of `EscalateRecord[]`. Persists independently of the 1-hour patch cache TTL.
+
+### Per-project config additions — `hexops.config.json`
+
+```json
+{
+  "projects": {
+    "my-project": {
+      "escalation": {
+        "acceptedRiskMaxDays": 90,
+        "autoCommit": false,
+        "autoPush": false
+      }
+    }
+  }
+}
+```
+
+- `acceptedRiskMaxDays` — enforced ceiling on accept-risk expiry. Default: 90.
+- `autoCommit` / `autoPush` — controls force_override post-patch behavior. Default: false.
+- Force Major Bump **ignores** these settings — always manual, no exceptions.
+
+---
+
+## Backend
+
+### New API Routes
+
+**`POST /api/projects/[id]/escalate`**
+
+Request body:
+```typescript
+{
+  package: string
+  action: 'force_override' | 'force_major' | 'accepted_risk'
+  reason: string
+  overrideVersion?: string      // force_override
+  targetVersion?: string        // force_major
+  expiresAt?: string            // accepted_risk
+  emergency?: boolean           // force_override only — bypasses autoCommit/autoPush config
+}
+```
+
+Action execution:
+- `force_override` — injects `overrides`/`resolutions` entry into `package.json`, runs `lockfile-resolver.ts` to regenerate lockfile, then commits + pushes per project config (or immediately if `emergency: true`).
+- `force_major` — updates dep version in `package.json` only. Never commits. Returns a pending state for UI banner.
+- `accepted_risk` — writes `EscalateRecord` only. No file changes.
+
+**`DELETE /api/projects/[id]/escalate/[escalationId]`**
+
+Removes the escalation record. Vuln re-surfaces in the patch queue on next scan.
+
+Escalation data is served through the existing patches stream — no dedicated GET route needed.
+
+### Scanner Integration — `patch-scanner.ts`
+
+After building `PatchQueueItem[]`, load `escalations.json` and process each vuln:
+
+| Condition | Behavior |
+|-----------|----------|
+| `accepted_risk` + not expired | Suppress from queue. Add to separate accepted-risk list. |
+| `accepted_risk` + expired | Re-surface in queue with `escalationExpired: true` flag. |
+| `force_override` or `force_major` + npm audit now shows `fixAvailable: true` | Set `resolvedAt` on record. Re-surface as normal patchable item. |
+
+The scanner is the source of truth for expiry and resolution detection. No cron job needed — checks run on every scan.
+
+---
+
+## Frontend
+
+### Escalate Button
+
+Appears on any `fixAvailable: false` row, **including Dependabot-managed projects** (currently these rows have no action). Secondary button styling alongside the severity badge.
+
+### `<EscalateModal>` — New Standalone Component
+
+Extracted from `patches/page.tsx` to keep the page manageable.
+
+**Structure:**
+- Header: package name + CVE/advisory link
+- Three option cards (radio-style selection):
+
+**Option 1 — Force Override**
+- Auto-detected safe pinned version shown
+- Auto-commit toggle (reflects project config default)
+- Auto-push toggle (reflects project config default, only enabled if auto-commit on)
+- **"Oh Shit" button** — red, labeled "Patch Now". Visible only when Force Override is selected. Ignores all config — commits and pushes immediately.
+
+**Option 2 — Force Major Bump**
+- Target version displayed
+- Prominent breaking-changes warning
+- Confirms user understands this requires manual review before merge
+
+**Option 3 — Accept Risk**
+- Required reason field (text, cannot submit empty)
+- Expiry date picker — capped at `acceptedRiskMaxDays` from project config
+- Shows calculated expiry clearly ("Expires April 21, 2026")
+
+### Accepted Risk Panel
+
+Collapsible section below the main patch queue, per project. Only shown when project has active accepted-risk records.
+
+- Package name, reason, expiry countdown ("Expires in 14 days")
+- Expired entries float to top with red "Expired" badge — no longer suppressed from queue
+- "Reverse" button — calls DELETE endpoint, removes record
+
+### Pending Major Bump Banner
+
+Amber banner at top of project section when a `force_major` escalation is pending (no `resolvedAt`).
+
+- Shows: package name, current → target version
+- "Review & Commit" CTA — opens file diff view or links to the project directory
+
+### Expired Badge
+
+Vulns with an expired `accepted_risk` record re-appear in the main queue with an "Expired" tag. Visually distinct from new findings so the user knows this was a prior accepted-risk, not a new discovery.
+
+---
+
+## Error Handling
+
+- `force_override` with lockfile regeneration failure → surface error in the escalate modal, do not write `EscalateRecord`. User must resolve lockfile manually before escalating.
+- `accepted_risk` with missing reason → block form submission client-side.
+- `accepted_risk` with expiry exceeding `acceptedRiskMaxDays` → clamp to max silently, show clamped date to user before submit.
+- DELETE on a non-existent escalation → 404, UI removes the record optimistically anyway.
+
+---
+
+## What This Does Not Cover
+
+- Branch propagation after Dependabot merges — tracked separately in #71
+- Auto-detection of when a Force Major Bump has been committed (no `resolvedAt` auto-set for major bumps — user must manually reverse the escalation after merging)
+
+---
+
+## Related Issues
+
+- #70 — This feature
+- #71 — Branch propagation (separate PR)
+- #68 — Self-advisory transitive vulns (fixed in v0.12.0)
+- #64 — Override-aware patching (related, precursor work)
+- #65 — Dependabot monitor mode (related integration)

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lucide-react": "^1.8.0",
     "next": "16.2.4",
     "node-pty": "^1.1.0",
+    "radix-ui": "^1.4.3",
     "react": "19.2.5",
     "react-apexcharts": "^2.1.0",
     "react-dom": "19.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexops",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "author": "Hexaxia Technologies",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "clsx": "^2.1.1",
     "framer-motion": "^12.38.0",
     "lucide-react": "^0.577.0",
-    "next": "16.2.1",
+    "next": "16.2.4",
     "node-pty": "^1.1.0",
-    "react": "19.2.4",
+    "react": "19.2.5",
     "react-apexcharts": "^2.1.0",
-    "react-dom": "19.2.4",
+    "react-dom": "19.2.5",
     "recharts": "^3.8.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
@@ -46,7 +46,7 @@
     }
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.8",
+    "@biomejs/biome": "2.4.12",
     "@tailwindcss/postcss": "4.2.2",
     "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.38.0",
-    "lucide-react": "^0.577.0",
+    "lucide-react": "^1.8.0",
     "next": "16.2.4",
     "node-pty": "^1.1.0",
     "react": "19.2.5",
@@ -55,6 +55,6 @@
     "tailwindcss": "4.2.2",
     "tsx": "^4.21.0",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
+      radix-ui:
+        specifier: ^1.4.3
+        version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
         specifier: 19.2.5
         version: 19.2.5
@@ -570,8 +573,99 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/react-accessible-icon@1.1.7':
+    resolution: {integrity: sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-accordion@1.2.12':
+    resolution: {integrity: sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-alert-dialog@1.1.15':
+    resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-aspect-ratio@1.1.7':
+    resolution: {integrity: sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-avatar@1.1.10':
+    resolution: {integrity: sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-checkbox@1.3.3':
+    resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collapsible@1.1.12':
+    resolution: {integrity: sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -603,6 +697,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-context-menu@2.2.16':
+    resolution: {integrity: sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-context@1.1.2':
@@ -649,6 +756,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dropdown-menu@2.1.16':
+    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-guards@1.1.3':
     resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
@@ -671,6 +791,32 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-form@0.1.8':
+    resolution: {integrity: sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-hover-card@1.1.15':
+    resolution: {integrity: sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-id@1.1.1':
     resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
     peerDependencies:
@@ -678,6 +824,97 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-label@2.1.7':
+    resolution: {integrity: sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.16':
+    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menubar@1.1.16':
+    resolution: {integrity: sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-navigation-menu@1.2.14':
+    resolution: {integrity: sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-one-time-password-field@0.1.8':
+    resolution: {integrity: sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-password-toggle-field@0.1.3':
+    resolution: {integrity: sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.15':
+    resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-popper@1.2.8':
@@ -732,6 +969,45 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-progress@1.1.7':
+    resolution: {integrity: sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.3.8':
+    resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.11':
+    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-scroll-area@1.2.10':
     resolution: {integrity: sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==}
     peerDependencies:
@@ -747,6 +1023,32 @@ packages:
 
   '@radix-ui/react-select@2.2.6':
     resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-separator@1.1.7':
+    resolution: {integrity: sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slider@1.3.6':
+    resolution: {integrity: sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -774,6 +1076,97 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-switch@1.2.6':
+    resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.13':
+    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toast@1.2.15':
+    resolution: {integrity: sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.11':
+    resolution: {integrity: sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.10':
+    resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toolbar@1.1.11':
+    resolution: {integrity: sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.8':
+    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.1.1':
@@ -805,6 +1198,15 @@ packages:
 
   '@radix-ui/react-use-escape-keydown@1.1.1':
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.0':
+    resolution: {integrity: sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1311,6 +1713,19 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  radix-ui@1.4.3:
+    resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   react-apexcharts@2.1.0:
     resolution: {integrity: sha512-xrmeTKRKHh3cvvLc8SasqFjlOgIqGpyHc81qjnRtcjUM0Fu7qEjgVRWGPokGFjqhwRZVgEym8zmuEyYr5LMYIg==}
     peerDependencies:
@@ -1785,9 +2200,103 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/react-accessible-icon@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-aspect-ratio@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-avatar@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
@@ -1811,6 +2320,20 @@ snapshots:
       react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-context-menu@2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
@@ -1859,6 +2382,21 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       react: 19.2.5
@@ -1876,12 +2414,177 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-form@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-hover-card@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-label@2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      aria-hidden: 1.2.6
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-menubar@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-navigation-menu@1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-one-time-password-field@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-password-toggle-field@0.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      aria-hidden: 1.2.6
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
@@ -1924,6 +2627,51 @@ snapshots:
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-progress@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
@@ -1976,6 +2724,34 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-separator@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slider@1.3.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
@@ -1989,6 +2765,118 @@ snapshots:
       react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toast@1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toolbar@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
@@ -2015,6 +2903,13 @@ snapshots:
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      use-sync-external-store: 1.6.0(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -2442,6 +3337,69 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-accessible-icon': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-alert-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-aspect-ratio': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-avatar': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context-menu': 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-form': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-hover-card': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-menubar': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-navigation-menu': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-one-time-password-field': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-password-toggle-field': 0.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-progress': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-radio-group': 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-scroll-area': 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-select': 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slider': 1.3.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-toast': 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-toolbar': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   react-apexcharts@2.1.0(apexcharts@5.10.6)(react@19.2.5):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,16 +13,16 @@ importers:
     dependencies:
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
-        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-scroll-area':
         specifier: ^1.2.10
-        version: 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-select':
         specifier: ^2.2.6
-        version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-slot':
         specifier: ^1.2.4
-        version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
+        version: 1.2.4(@types/react@19.2.14)(react@19.2.5)
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
@@ -31,7 +31,7 @@ importers:
         version: 6.0.0
       apexcharts:
         specifier: ^5.10.4
-        version: 5.10.4
+        version: 5.10.6
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -40,47 +40,47 @@ importers:
         version: 2.1.1
       framer-motion:
         specifier: ^12.38.0
-        version: 12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       lucide-react:
         specifier: ^0.577.0
-        version: 0.577.0(react@19.2.4)
+        version: 0.577.0(react@19.2.5)
       next:
-        specifier: 16.2.1
-        version: 16.2.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 16.2.4
+        version: 16.2.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
       react:
-        specifier: 19.2.4
-        version: 19.2.4
+        specifier: 19.2.5
+        version: 19.2.5
       react-apexcharts:
         specifier: ^2.1.0
-        version: 2.1.0(apexcharts@5.10.4)(react@19.2.4)
+        version: 2.1.0(apexcharts@5.10.6)(react@19.2.5)
       react-dom:
-        specifier: 19.2.4
-        version: 19.2.4(react@19.2.4)
+        specifier: 19.2.5
+        version: 19.2.5(react@19.2.5)
       recharts:
         specifier: ^3.8.0
-        version: 3.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@16.13.1)(react@19.2.4)(redux@5.0.1)
+        version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(redux@5.0.1)
       sonner:
         specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
       ws:
         specifier: ^8.19.0
-        version: 8.19.0
+        version: 8.20.0
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.4.8
-        version: 2.4.8
+        specifier: 2.4.12
+        version: 2.4.12
       '@tailwindcss/postcss':
         specifier: 4.2.2
         version: 4.2.2
       '@types/node':
         specifier: ^25.5.0
-        version: 25.5.0
+        version: 25.6.0
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -109,65 +109,65 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@biomejs/biome@2.4.8':
-    resolution: {integrity: sha512-ponn0oKOky1oRXBV+rlSaUlixUxf1aZvWC19Z41zBfUOUesthrQqL3OtiAlSB1EjFjyWpn98Q64DHelhA6jNlA==}
+  '@biomejs/biome@2.4.12':
+    resolution: {integrity: sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.4.8':
-    resolution: {integrity: sha512-ARx0tECE8I7S2C2yjnWYLNbBdDoPdq3oyNLhMglmuctThwUsuzFWRKrHmIGwIRWKz0Mat9DuzLEDp52hGnrxGQ==}
+  '@biomejs/cli-darwin-arm64@2.4.12':
+    resolution: {integrity: sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.4.8':
-    resolution: {integrity: sha512-Jg9/PsB9vDCJlANE8uhG7qDhb5w0Ix69D7XIIc8IfZPUoiPrbLm33k2Ig3NOJ/7nb3UbesFz3D1aDKm9DvzjhQ==}
+  '@biomejs/cli-darwin-x64@2.4.12':
+    resolution: {integrity: sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.4.8':
-    resolution: {integrity: sha512-Zo9OhBQDJ3IBGPlqHiTISloo5H0+FBIpemqIJdW/0edJ+gEcLR+MZeZozcUyz3o1nXkVA7++DdRKQT0599j9jA==}
+  '@biomejs/cli-linux-arm64-musl@2.4.12':
+    resolution: {integrity: sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.4.8':
-    resolution: {integrity: sha512-5CdrsJct76XG2hpKFwXnEtlT1p+4g4yV+XvvwBpzKsTNLO9c6iLlAxwcae2BJ7ekPGWjNGw9j09T5KGPKKxQig==}
+  '@biomejs/cli-linux-arm64@2.4.12':
+    resolution: {integrity: sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.4.8':
-    resolution: {integrity: sha512-Gi8quv8MEuDdKaPFtS2XjEnMqODPsRg6POT6KhoP+VrkNb+T2ywunVB+TvOU0LX1jAZzfBr+3V1mIbBhzAMKvw==}
+  '@biomejs/cli-linux-x64-musl@2.4.12':
+    resolution: {integrity: sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.4.8':
-    resolution: {integrity: sha512-PdKXspVEaMCQLjtZCn6vfSck/li4KX9KGwSDbZdgIqlrizJ2MnMcE3TvHa2tVfXNmbjMikzcfJpuPWH695yJrw==}
+  '@biomejs/cli-linux-x64@2.4.12':
+    resolution: {integrity: sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.4.8':
-    resolution: {integrity: sha512-LoFatS0tnHv6KkCVpIy3qZCih+MxUMvdYiPWLHRri7mhi2vyOOs8OrbZBcLTUEWCS+ktO72nZMy4F96oMhkOHQ==}
+  '@biomejs/cli-win32-arm64@2.4.12':
+    resolution: {integrity: sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.4.8':
-    resolution: {integrity: sha512-vAn7iXDoUbqFXqVocuq1sMYAd33p8+mmurqJkWl6CtIhobd/O6moe4rY5AJvzbunn/qZCdiDVcveqtkFh1e7Hg==}
+  '@biomejs/cli-win32-x64@2.4.12':
+    resolution: {integrity: sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
 
-  '@emnapi/runtime@1.8.1':
-    resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -325,23 +325,23 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@floating-ui/core@1.7.4':
-    resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
-  '@floating-ui/dom@1.7.5':
-    resolution: {integrity: sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==}
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
 
-  '@floating-ui/react-dom@2.1.7':
-    resolution: {integrity: sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==}
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@floating-ui/utils@0.2.10':
-    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@img/colour@1.0.0':
-    resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
   '@img/sharp-darwin-arm64@0.34.5':
@@ -509,57 +509,57 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@next/env@16.2.1':
-    resolution: {integrity: sha512-n8P/HCkIWW+gVal2Z8XqXJ6aB3J0tuM29OcHpCsobWlChH/SITBs1DFBk/HajgrwDkqqBXPbuUuzgDvUekREPg==}
+  '@next/env@16.2.4':
+    resolution: {integrity: sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==}
 
-  '@next/swc-darwin-arm64@16.2.1':
-    resolution: {integrity: sha512-BwZ8w8YTaSEr2HIuXLMLxIdElNMPvY9fLqb20LX9A9OMGtJilhHLbCL3ggyd0TwjmMcTxi0XXt+ur1vWUoxj2Q==}
+  '@next/swc-darwin-arm64@16.2.4':
+    resolution: {integrity: sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.1':
-    resolution: {integrity: sha512-/vrcE6iQSJq3uL3VGVHiXeaKbn8Es10DGTGRJnRZlkNQQk3kaNtAJg8Y6xuAlrx/6INKVjkfi5rY0iEXorZ6uA==}
+  '@next/swc-darwin-x64@16.2.4':
+    resolution: {integrity: sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.1':
-    resolution: {integrity: sha512-uLn+0BK+C31LTVbQ/QU+UaVrV0rRSJQ8RfniQAHPghDdgE+SlroYqcmFnO5iNjNfVWCyKZHYrs3Nl0mUzWxbBw==}
+  '@next/swc-linux-arm64-gnu@16.2.4':
+    resolution: {integrity: sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.2.1':
-    resolution: {integrity: sha512-ssKq6iMRnHdnycGp9hCuGnXJZ0YPr4/wNwrfE5DbmvEcgl9+yv97/Kq3TPVDfYome1SW5geciLB9aiEqKXQjlQ==}
+  '@next/swc-linux-arm64-musl@16.2.4':
+    resolution: {integrity: sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.2.1':
-    resolution: {integrity: sha512-HQm7SrHRELJ30T1TSmT706IWovFFSRGxfgUkyWJZF/RKBMdbdRWJuFrcpDdE5vy9UXjFOx6L3mRdqH04Mmx0hg==}
+  '@next/swc-linux-x64-gnu@16.2.4':
+    resolution: {integrity: sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.2.1':
-    resolution: {integrity: sha512-aV2iUaC/5HGEpbBkE+4B8aHIudoOy5DYekAKOMSHoIYQ66y/wIVeaRx8MS2ZMdxe/HIXlMho4ubdZs/J8441Tg==}
+  '@next/swc-linux-x64-musl@16.2.4':
+    resolution: {integrity: sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.2.1':
-    resolution: {integrity: sha512-IXdNgiDHaSk0ZUJ+xp0OQTdTgnpx1RCfRTalhn3cjOP+IddTMINwA7DXZrwTmGDO8SUr5q2hdP/du4DcrB1GxA==}
+  '@next/swc-win32-arm64-msvc@16.2.4':
+    resolution: {integrity: sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.1':
-    resolution: {integrity: sha512-qvU+3a39Hay+ieIztkGSbF7+mccbbg1Tk25hc4JDylf8IHjYmY/Zm64Qq1602yPyQqvie+vf5T/uPwNxDNIoeg==}
+  '@next/swc-win32-x64-msvc@16.2.4':
+    resolution: {integrity: sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1003,8 +1003,8 @@ packages:
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
-  '@types/node@25.5.0':
-    resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -1026,20 +1026,20 @@ packages:
   '@xterm/xterm@6.0.0':
     resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
 
-  apexcharts@5.10.4:
-    resolution: {integrity: sha512-gt0VUqZ2+mr25ScbUcKZgJr96jKYm4vjOcxEWCEh/E5F4dWqhyo3dBhPRvNNnkKiWxkMd2cBwj3ZYH3rK39fkA==}
+  apexcharts@5.10.6:
+    resolution: {integrity: sha512-FJQGbso3iRuOwUYnj0yUhkWeKeJE6aboVol+ae09lsc+lbLMWZqSRbrAWVa/qishLiaeG2icxdvmVkm+9n6kOQ==}
 
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
-  baseline-browser-mapping@2.10.0:
-    resolution: {integrity: sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==}
+  baseline-browser-mapping@2.10.18:
+    resolution: {integrity: sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  caniuse-lite@1.0.30001774:
-    resolution: {integrity: sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==}
+  caniuse-lite@1.0.30001787:
+    resolution: {integrity: sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -1108,12 +1108,12 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
-  enhanced-resolve@5.19.0:
-    resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
+  enhanced-resolve@5.20.1:
+    resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
-  es-toolkit@1.44.0:
-    resolution: {integrity: sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==}
+  es-toolkit@1.45.1:
+    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -1266,8 +1266,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  next@16.2.1:
-    resolution: {integrity: sha512-VaChzNL7o9rbfdt60HUj8tev4m6d7iC1igAy157526+cJlXOQu5LzsBXNT+xaJnTP/k+utSX5vMv7m0G+zKH+Q==}
+  next@16.2.4:
+    resolution: {integrity: sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -1304,8 +1304,8 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.9:
+    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
 
   prop-types@15.8.1:
@@ -1317,10 +1317,10 @@ packages:
       apexcharts: '>=5.10.1'
       react: '>=16.8.0'
 
-  react-dom@19.2.4:
-    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
-      react: ^19.2.4
+      react: ^19.2.5
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -1367,12 +1367,12 @@ packages:
       '@types/react':
         optional: true
 
-  react@19.2.4:
-    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
 
-  recharts@3.8.0:
-    resolution: {integrity: sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==}
+  recharts@3.8.1:
+    resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -1434,8 +1434,8 @@ packages:
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
 
-  tapable@2.3.0:
-    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+  tapable@2.3.2:
+    resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
   tiny-invariant@1.3.3:
@@ -1457,8 +1457,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -1488,8 +1488,8 @@ packages:
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -1504,42 +1504,42 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@biomejs/biome@2.4.8':
+  '@biomejs/biome@2.4.12':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.8
-      '@biomejs/cli-darwin-x64': 2.4.8
-      '@biomejs/cli-linux-arm64': 2.4.8
-      '@biomejs/cli-linux-arm64-musl': 2.4.8
-      '@biomejs/cli-linux-x64': 2.4.8
-      '@biomejs/cli-linux-x64-musl': 2.4.8
-      '@biomejs/cli-win32-arm64': 2.4.8
-      '@biomejs/cli-win32-x64': 2.4.8
+      '@biomejs/cli-darwin-arm64': 2.4.12
+      '@biomejs/cli-darwin-x64': 2.4.12
+      '@biomejs/cli-linux-arm64': 2.4.12
+      '@biomejs/cli-linux-arm64-musl': 2.4.12
+      '@biomejs/cli-linux-x64': 2.4.12
+      '@biomejs/cli-linux-x64-musl': 2.4.12
+      '@biomejs/cli-win32-arm64': 2.4.12
+      '@biomejs/cli-win32-x64': 2.4.12
 
-  '@biomejs/cli-darwin-arm64@2.4.8':
+  '@biomejs/cli-darwin-arm64@2.4.12':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.4.8':
+  '@biomejs/cli-darwin-x64@2.4.12':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.4.8':
+  '@biomejs/cli-linux-arm64-musl@2.4.12':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.4.8':
+  '@biomejs/cli-linux-arm64@2.4.12':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.4.8':
+  '@biomejs/cli-linux-x64-musl@2.4.12':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.4.8':
+  '@biomejs/cli-linux-x64@2.4.12':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.4.8':
+  '@biomejs/cli-win32-arm64@2.4.12':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.4.8':
+  '@biomejs/cli-win32-x64@2.4.12':
     optional: true
 
-  '@emnapi/runtime@1.8.1':
+  '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -1622,24 +1622,24 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@floating-ui/core@1.7.4':
+  '@floating-ui/core@1.7.5':
     dependencies:
-      '@floating-ui/utils': 0.2.10
+      '@floating-ui/utils': 0.2.11
 
-  '@floating-ui/dom@1.7.5':
+  '@floating-ui/dom@1.7.6':
     dependencies:
-      '@floating-ui/core': 1.7.4
-      '@floating-ui/utils': 0.2.10
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
 
-  '@floating-ui/react-dom@2.1.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@floating-ui/dom': 1.7.5
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
-  '@floating-ui/utils@0.2.10': {}
+  '@floating-ui/utils@0.2.11': {}
 
-  '@img/colour@1.0.0':
+  '@img/colour@1.1.0':
     optional: true
 
   '@img/sharp-darwin-arm64@0.34.5':
@@ -1724,7 +1724,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.8.1
+      '@emnapi/runtime': 1.9.2
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -1755,307 +1755,307 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@next/env@16.2.1': {}
+  '@next/env@16.2.4': {}
 
-  '@next/swc-darwin-arm64@16.2.1':
+  '@next/swc-darwin-arm64@16.2.4':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.1':
+  '@next/swc-darwin-x64@16.2.4':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.1':
+  '@next/swc-linux-arm64-gnu@16.2.4':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.1':
+  '@next/swc-linux-arm64-musl@16.2.4':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.1':
+  '@next/swc-linux-x64-gnu@16.2.4':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.1':
+  '@next/swc-linux-x64-musl@16.2.4':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.1':
+  '@next/swc-win32-arm64-msvc@16.2.4':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.1':
+  '@next/swc-win32-x64-msvc@16.2.4':
     optional: true
 
   '@radix-ui/number@1.1.1': {}
 
   '@radix-ui/primitive@1.1.3': {}
 
-  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
-      react: 19.2.4
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
-      react: 19.2.4
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
       aria-hidden: 1.2.6
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-direction@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+  '@radix-ui/react-direction@1.1.1(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
-      react: 19.2.4
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
-      react: 19.2.4
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      react: 19.2.4
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.5)
       '@radix-ui/rect': 1.1.1
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/number': 1.1.1
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-select@2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-select@2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/number': 1.1.1
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       aria-hidden: 1.2.6
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.4)':
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      react: 19.2.4
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4)':
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      react: 19.2.4
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
-      react: 19.2.4
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.4)':
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      react: 19.2.4
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.4)':
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      react: 19.2.4
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      react: 19.2.4
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
-      react: 19.2.4
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+  '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
-      react: 19.2.4
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       '@radix-ui/rect': 1.1.1
-      react: 19.2.4
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      react: 19.2.4
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1))(react@19.2.5)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@standard-schema/utils': 0.3.0
@@ -2064,8 +2064,8 @@ snapshots:
       redux-thunk: 3.1.0(redux@5.0.1)
       reselect: 5.1.1
     optionalDependencies:
-      react: 19.2.4
-      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+      react: 19.2.5
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1)
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -2078,7 +2078,7 @@ snapshots:
   '@tailwindcss/node@4.2.2':
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      enhanced-resolve: 5.19.0
+      enhanced-resolve: 5.20.1
       jiti: 2.6.1
       lightningcss: 1.32.0
       magic-string: 0.30.21
@@ -2141,7 +2141,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
-      postcss: 8.5.6
+      postcss: 8.5.9
       tailwindcss: 4.2.2
 
   '@types/d3-array@3.2.2': {}
@@ -2168,9 +2168,9 @@ snapshots:
 
   '@types/d3-timer@3.0.2': {}
 
-  '@types/node@25.5.0':
+  '@types/node@25.6.0':
     dependencies:
-      undici-types: 7.18.2
+      undici-types: 7.19.2
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -2184,21 +2184,21 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
 
   '@xterm/addon-fit@0.11.0': {}
 
   '@xterm/xterm@6.0.0': {}
 
-  apexcharts@5.10.4: {}
+  apexcharts@5.10.6: {}
 
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
 
-  baseline-browser-mapping@2.10.0: {}
+  baseline-browser-mapping@2.10.18: {}
 
-  caniuse-lite@1.0.30001774: {}
+  caniuse-lite@1.0.30001787: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -2254,12 +2254,12 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
-  enhanced-resolve@5.19.0:
+  enhanced-resolve@5.20.1:
     dependencies:
       graceful-fs: 4.2.11
-      tapable: 2.3.0
+      tapable: 2.3.2
 
-  es-toolkit@1.44.0: {}
+  es-toolkit@1.45.1: {}
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -2292,14 +2292,14 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
-  framer-motion@12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  framer-motion@12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       motion-dom: 12.38.0
       motion-utils: 12.36.0
       tslib: 2.8.1
     optionalDependencies:
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   fsevents@2.3.3:
     optional: true
@@ -2375,9 +2375,9 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  lucide-react@0.577.0(react@19.2.4):
+  lucide-react@0.577.0(react@19.2.5):
     dependencies:
-      react: 19.2.4
+      react: 19.2.5
 
   magic-string@0.30.21:
     dependencies:
@@ -2391,25 +2391,25 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  next@16.2.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@next/env': 16.2.1
+      '@next/env': 16.2.4
       '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.0
-      caniuse-lite: 1.0.30001774
+      baseline-browser-mapping: 2.10.18
+      caniuse-lite: 1.0.30001787
       postcss: 8.4.31
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(react@19.2.4)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      styled-jsx: 5.1.6(react@19.2.5)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.1
-      '@next/swc-darwin-x64': 16.2.1
-      '@next/swc-linux-arm64-gnu': 16.2.1
-      '@next/swc-linux-arm64-musl': 16.2.1
-      '@next/swc-linux-x64-gnu': 16.2.1
-      '@next/swc-linux-x64-musl': 16.2.1
-      '@next/swc-win32-arm64-msvc': 16.2.1
-      '@next/swc-win32-x64-msvc': 16.2.1
+      '@next/swc-darwin-arm64': 16.2.4
+      '@next/swc-darwin-x64': 16.2.4
+      '@next/swc-linux-arm64-gnu': 16.2.4
+      '@next/swc-linux-arm64-musl': 16.2.4
+      '@next/swc-linux-x64-gnu': 16.2.4
+      '@next/swc-linux-x64-musl': 16.2.4
+      '@next/swc-win32-arm64-msvc': 16.2.4
+      '@next/swc-win32-x64-msvc': 16.2.4
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -2431,7 +2431,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.6:
+  postcss@8.5.9:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -2443,72 +2443,72 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
-  react-apexcharts@2.1.0(apexcharts@5.10.4)(react@19.2.4):
+  react-apexcharts@2.1.0(apexcharts@5.10.6)(react@19.2.5):
     dependencies:
-      apexcharts: 5.10.4
+      apexcharts: 5.10.6
       prop-types: 15.8.1
-      react: 19.2.4
+      react: 19.2.5
 
-  react-dom@19.2.4(react@19.2.4):
+  react-dom@19.2.5(react@19.2.5):
     dependencies:
-      react: 19.2.4
+      react: 19.2.5
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
 
-  react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1):
+  react-redux@9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1):
     dependencies:
       '@types/use-sync-external-store': 0.0.6
-      react: 19.2.4
-      use-sync-external-store: 1.6.0(react@19.2.4)
+      react: 19.2.5
+      use-sync-external-store: 1.6.0(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
       redux: 5.0.1
 
-  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.5):
     dependencies:
-      react: 19.2.4
-      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.5
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.5)
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.4):
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.5):
     dependencies:
-      react: 19.2.4
-      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.4)
-      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.5
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.5)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.5)
       tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.4)
-      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.5)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.5):
     dependencies:
       get-nonce: 1.0.1
-      react: 19.2.4
+      react: 19.2.5
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react@19.2.4: {}
+  react@19.2.5: {}
 
-  recharts@3.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@16.13.1)(react@19.2.4)(redux@5.0.1):
+  recharts@3.8.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(redux@5.0.1):
     dependencies:
-      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1))(react@19.2.5)
       clsx: 2.1.1
       decimal.js-light: 2.5.1
-      es-toolkit: 1.44.0
+      es-toolkit: 1.45.1
       eventemitter3: 5.0.4
       immer: 10.2.0
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
       react-is: 16.13.1
-      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1)
       reselect: 5.1.1
       tiny-invariant: 1.3.3
-      use-sync-external-store: 1.6.0(react@19.2.4)
+      use-sync-external-store: 1.6.0(react@19.2.5)
       victory-vendor: 37.3.6
     transitivePeerDependencies:
       - '@types/react'
@@ -2531,7 +2531,7 @@ snapshots:
 
   sharp@0.34.5:
     dependencies:
-      '@img/colour': 1.0.0
+      '@img/colour': 1.1.0
       detect-libc: 2.1.2
       semver: 7.7.4
     optionalDependencies:
@@ -2561,23 +2561,23 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.5
     optional: true
 
-  sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  sonner@2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   source-map-js@1.2.1: {}
 
-  styled-jsx@5.1.6(react@19.2.4):
+  styled-jsx@5.1.6(react@19.2.5):
     dependencies:
       client-only: 0.0.1
-      react: 19.2.4
+      react: 19.2.5
 
   tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.2: {}
 
-  tapable@2.3.0: {}
+  tapable@2.3.2: {}
 
   tiny-invariant@1.3.3: {}
 
@@ -2594,26 +2594,26 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici-types@7.18.2: {}
+  undici-types@7.19.2: {}
 
-  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.5):
     dependencies:
-      react: 19.2.4
+      react: 19.2.5
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
 
-  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.4):
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.5):
     dependencies:
       detect-node-es: 1.1.0
-      react: 19.2.4
+      react: 19.2.5
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
 
-  use-sync-external-store@1.6.0(react@19.2.4):
+  use-sync-external-store@1.6.0(react@19.2.5):
     dependencies:
-      react: 19.2.4
+      react: 19.2.5
 
   victory-vendor@37.3.6:
     dependencies:
@@ -2632,4 +2632,4 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  ws@8.19.0: {}
+  ws@8.20.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       lucide-react:
-        specifier: ^0.577.0
-        version: 0.577.0(react@19.2.5)
+        specifier: ^1.8.0
+        version: 1.8.0(react@19.2.5)
       next:
         specifier: 16.2.4
         version: 16.2.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -100,8 +100,8 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
 
 packages:
 
@@ -1247,8 +1247,8 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  lucide-react@0.577.0:
-    resolution: {integrity: sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==}
+  lucide-react@1.8.0:
+    resolution: {integrity: sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -1452,8 +1452,8 @@ packages:
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2375,7 +2375,7 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  lucide-react@0.577.0(react@19.2.5):
+  lucide-react@1.8.0(react@19.2.5):
     dependencies:
       react: 19.2.5
 
@@ -2592,7 +2592,7 @@ snapshots:
 
   tw-animate-css@1.4.0: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.2: {}
 
   undici-types@7.19.2: {}
 

--- a/src/app/api/projects/[id]/branch-sync/route.ts
+++ b/src/app/api/projects/[id]/branch-sync/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import { getProject } from '@/lib/config';
+import {
+  getActiveBranches,
+  getBranchSyncStatuses,
+  DEFAULT_PROPAGATION_CONFIG,
+} from '@/lib/branch-propagator';
+import type { PropagationConfig } from '@/lib/types';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const project = getProject(id);
+
+  if (!project) {
+    return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+  }
+
+  const config: PropagationConfig = {
+    ...DEFAULT_PROPAGATION_CONFIG,
+    ...project.propagation,
+  };
+
+  try {
+    const activeBranches = await getActiveBranches(project.path, config.activeBranchDays);
+
+    if (activeBranches.length === 0) {
+      return NextResponse.json({ branches: [], config });
+    }
+
+    const branches = await getBranchSyncStatuses(project.path, activeBranches);
+    return NextResponse.json({ branches, config });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Branch sync check failed' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/projects/[id]/dependabot/route.ts
+++ b/src/app/api/projects/[id]/dependabot/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server';
+import { getProject, loadConfig } from '@/lib/config';
+import { detectDependabot } from '@/lib/dependabot-detector';
+import { fetchDependabotPRs } from '@/lib/github-client';
+import type { DependabotConfig, DependabotPR } from '@/lib/types';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const project = getProject(id);
+
+  if (!project) {
+    return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+  }
+
+  const detection = await detectDependabot(project.path);
+
+  if (!detection.managed) {
+    const result: DependabotConfig = {
+      managed: false,
+      owner: null,
+      repo: null,
+      prs: [],
+      fetchedAt: null,
+      error: null,
+    };
+    return NextResponse.json(result);
+  }
+
+  const config = loadConfig();
+  const token = config.settings?.integrations?.github?.token ?? null;
+
+  const owner = project.github?.owner ?? detection.owner;
+  const repo = project.github?.repo ?? detection.repo;
+
+  let prs: DependabotPR[] = [];
+  let error: string | null = null;
+
+  if (owner && repo) {
+    try {
+      prs = await fetchDependabotPRs(owner, repo, token);
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Unknown error fetching PRs';
+    }
+  } else {
+    error = 'Could not determine GitHub owner/repo from git remote';
+  }
+
+  const result: DependabotConfig = {
+    managed: true,
+    owner,
+    repo,
+    prs,
+    fetchedAt: new Date().toISOString(),
+    error,
+  };
+
+  return NextResponse.json(result);
+}

--- a/src/app/api/projects/[id]/escalate/route.ts
+++ b/src/app/api/projects/[id]/escalate/route.ts
@@ -1,0 +1,189 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getProject } from '@/lib/config'
+import { addEscalation, removeEscalation, getEscalationConfig } from '@/lib/escalation-store'
+import { resolveLockfile } from '@/lib/lockfile-resolver'
+import type { EscalateAction, EscalateRecord } from '@/lib/types'
+import { readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+
+const execFileAsync = promisify(execFile)
+
+const LOCK_FILES: Record<string, string> = {
+  pnpm: 'pnpm-lock.yaml',
+  npm: 'package-lock.json',
+  yarn: 'yarn.lock',
+}
+
+interface EscalateRequestBody {
+  package: string
+  action: EscalateAction
+  reason: string
+  overrideVersion?: string
+  targetVersion?: string
+  expiresAt?: string
+  emergency?: boolean
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+
+  try {
+    const project = getProject(id)
+
+    if (!project) {
+      return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+    }
+
+    const body: EscalateRequestBody = await request.json()
+    const { package: pkg, action, reason, overrideVersion, targetVersion, expiresAt, emergency } = body
+
+    if (!pkg || !action || !reason) {
+      return NextResponse.json(
+        { error: 'package, action, and reason are required' },
+        { status: 400 }
+      )
+    }
+
+    const escalationCfg = getEscalationConfig(project)
+
+    const record: EscalateRecord = {
+      id: crypto.randomUUID(),
+      projectId: id,
+      package: pkg,
+      action,
+      reason,
+      createdAt: new Date().toISOString(),
+    }
+
+    if (action === 'force_override') {
+      if (!overrideVersion) {
+        return NextResponse.json(
+          { error: 'overrideVersion is required for force_override' },
+          { status: 400 }
+        )
+      }
+
+      record.overrideVersion = overrideVersion
+
+      const pkgJsonPath = join(project.path, 'package.json')
+      const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'))
+
+      // Inject overrides
+      pkgJson.overrides = { ...pkgJson.overrides, [pkg]: overrideVersion }
+      if (pkgJson.pnpm) {
+        pkgJson.pnpm.overrides = { ...pkgJson.pnpm.overrides, [pkg]: overrideVersion }
+      }
+      writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n')
+
+      // Regenerate lockfile
+      const lockfileResult = await resolveLockfile(project.path, 'repair')
+
+      if (!lockfileResult.success) {
+        // Revert package.json on failure
+        await execFileAsync('git', ['checkout', '--', 'package.json'], { cwd: project.path })
+        return NextResponse.json(
+          { error: `Lockfile regeneration failed: ${lockfileResult.error}` },
+          { status: 500 }
+        )
+      }
+
+      const lockfileName = LOCK_FILES[lockfileResult.packageManager]
+
+      // Commit + push based on escalation config or emergency flag
+      const shouldCommit = escalationCfg.autoCommit || emergency
+      if (shouldCommit) {
+        await execFileAsync(
+          'git',
+          ['add', 'package.json', lockfileName],
+          { cwd: project.path }
+        )
+        await execFileAsync(
+          'git',
+          ['commit', '-m', `fix(deps): force override ${pkg}@${overrideVersion} — ${reason}`],
+          { cwd: project.path }
+        )
+
+        const shouldPush = escalationCfg.autoPush || emergency
+        if (shouldPush) {
+          await execFileAsync('git', ['push'], { cwd: project.path })
+        }
+      }
+    } else if (action === 'force_major') {
+      if (!targetVersion) {
+        return NextResponse.json(
+          { error: 'targetVersion is required for force_major' },
+          { status: 400 }
+        )
+      }
+
+      record.targetVersion = targetVersion
+
+      const pkgJsonPath = join(project.path, 'package.json')
+      const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'))
+
+      for (const section of ['dependencies', 'devDependencies', 'peerDependencies'] as const) {
+        if (pkgJson[section]?.[pkg]) {
+          pkgJson[section][pkg] = `^${targetVersion}`
+          break
+        }
+      }
+
+      writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n')
+      // Do NOT commit — leave dirty for human review
+    } else if (action === 'accepted_risk') {
+      if (expiresAt) {
+        record.expiresAt = expiresAt
+        const maxDate = new Date()
+        maxDate.setDate(maxDate.getDate() + escalationCfg.acceptedRiskMaxDays)
+        if (new Date(expiresAt) > maxDate) {
+          record.expiresAt = maxDate.toISOString()
+        }
+      }
+    }
+
+    addEscalation(record)
+
+    return NextResponse.json({ success: true, record })
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Escalation failed'
+    return NextResponse.json({ error: errorMessage }, { status: 500 })
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+
+  try {
+    const project = getProject(id)
+
+    if (!project) {
+      return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+    }
+
+    const body = await request.json()
+    const { escalationId } = body
+
+    if (!escalationId) {
+      return NextResponse.json({ error: 'escalationId is required' }, { status: 400 })
+    }
+
+    const removed = removeEscalation(escalationId)
+
+    if (!removed) {
+      return NextResponse.json({ error: 'Escalation not found' }, { status: 404 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Delete failed'
+    return NextResponse.json({ error: errorMessage }, { status: 500 })
+  }
+}

--- a/src/app/api/projects/[id]/escalate/route.ts
+++ b/src/app/api/projects/[id]/escalate/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getProject } from '@/lib/config'
 import { addEscalation, removeEscalation, getEscalationConfig } from '@/lib/escalation-store'
 import { resolveLockfile } from '@/lib/lockfile-resolver'
-import type { EscalateAction, EscalateRecord } from '@/lib/types'
+import { detectPackageManager } from '@/lib/patch-scanner'
+import type { EscalateAction, EscalateRecord, PackageManager } from '@/lib/types'
 import { readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { execFile } from 'child_process'
@@ -10,7 +11,7 @@ import { promisify } from 'util'
 
 const execFileAsync = promisify(execFile)
 
-const LOCK_FILES: Record<string, string> = {
+const LOCK_FILES: Record<PackageManager, string> = {
   pnpm: 'pnpm-lock.yaml',
   npm: 'package-lock.json',
   yarn: 'yarn.lock',
@@ -49,6 +50,24 @@ export async function POST(
       )
     }
 
+    // Validate action
+    const validActions: EscalateAction[] = ['force_override', 'force_major', 'accepted_risk']
+    if (!validActions.includes(action)) {
+      return NextResponse.json({ error: 'Invalid action' }, { status: 400 })
+    }
+
+    // Validate package name
+    if (!pkg || !/^[@a-z0-9][\w\-./@]*$/i.test(pkg)) {
+      return NextResponse.json({ error: 'Invalid package name' }, { status: 400 })
+    }
+    // Validate version strings (when present)
+    if (overrideVersion && !/^(latest|next|canary|[\w\-.^~<>=|@]+)$/i.test(overrideVersion)) {
+      return NextResponse.json({ error: 'Invalid override version' }, { status: 400 })
+    }
+    if (targetVersion && !/^(latest|next|canary|[\w\-.^~<>=|@]+)$/i.test(targetVersion)) {
+      return NextResponse.json({ error: 'Invalid target version' }, { status: 400 })
+    }
+
     const escalationCfg = getEscalationConfig(project)
 
     const record: EscalateRecord = {
@@ -71,47 +90,64 @@ export async function POST(
       record.overrideVersion = overrideVersion
 
       const pkgJsonPath = join(project.path, 'package.json')
-      const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'))
+      const pkgJsonRaw = readFileSync(pkgJsonPath, 'utf-8')
+      const pkgJson = JSON.parse(pkgJsonRaw)
 
-      // Inject overrides
-      pkgJson.overrides = { ...pkgJson.overrides, [pkg]: overrideVersion }
-      if (pkgJson.pnpm) {
-        pkgJson.pnpm.overrides = { ...pkgJson.pnpm.overrides, [pkg]: overrideVersion }
+      // Detect package manager before writing overrides so we use the correct key
+      const detectedPm = detectPackageManager(project.path) as PackageManager
+      const lockfileName = LOCK_FILES[detectedPm]
+
+      if (!lockfileName) {
+        return NextResponse.json({ error: `Unknown package manager: ${detectedPm}` }, { status: 500 })
       }
-      writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n')
 
-      // Regenerate lockfile
+      // Inject overrides using PM-aware key
+      if (detectedPm === 'pnpm') {
+        if (!pkgJson.pnpm) pkgJson.pnpm = {}
+        if (!pkgJson.pnpm.overrides) pkgJson.pnpm.overrides = {}
+        pkgJson.pnpm.overrides[pkg] = overrideVersion
+      } else if (detectedPm === 'npm') {
+        if (!pkgJson.overrides) pkgJson.overrides = {}
+        pkgJson.overrides[pkg] = overrideVersion
+      } else {
+        // yarn uses "resolutions"
+        if (!pkgJson.resolutions) pkgJson.resolutions = {}
+        pkgJson.resolutions[pkg] = overrideVersion
+      }
+
+      const indent = pkgJsonRaw.match(/^(\s+)/m)?.[1] || '  '
+      writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, indent) + '\n')
+
+      // Regenerate lockfile to pick up the new override
       const lockfileResult = await resolveLockfile(project.path, 'repair')
 
       if (!lockfileResult.success) {
         // Revert package.json on failure
-        await execFileAsync('git', ['checkout', '--', 'package.json'], { cwd: project.path })
+        await execFileAsync('git', ['checkout', '--', 'package.json'], { cwd: project.path, timeout: 30000 })
         return NextResponse.json(
           { error: `Lockfile regeneration failed: ${lockfileResult.error}` },
           { status: 500 }
         )
       }
 
-      const lockfileName = LOCK_FILES[lockfileResult.packageManager]
-
       // Commit + push based on escalation config or emergency flag
       const shouldCommit = escalationCfg.autoCommit || emergency
-      if (shouldCommit) {
-        await execFileAsync(
-          'git',
-          ['add', 'package.json', lockfileName],
-          { cwd: project.path }
-        )
-        await execFileAsync(
-          'git',
-          ['commit', '-m', `fix(deps): force override ${pkg}@${overrideVersion} — ${reason}`],
-          { cwd: project.path }
-        )
+      const shouldPush = escalationCfg.autoPush || emergency
 
-        const shouldPush = escalationCfg.autoPush || emergency
-        if (shouldPush) {
-          await execFileAsync('git', ['push'], { cwd: project.path })
+      try {
+        if (shouldCommit) {
+          await execFileAsync('git', ['add', 'package.json', lockfileName], { cwd: project.path, timeout: 30000 })
+          await execFileAsync('git', ['commit', '-m', `fix(deps): force override ${pkg}@${overrideVersion} — ${reason}`], { cwd: project.path, timeout: 30000 })
         }
+        if (shouldPush) {
+          await execFileAsync('git', ['push'], { cwd: project.path, timeout: 60000 })
+        }
+      } catch (commitErr) {
+        // Revert both package.json and lockfile on failure
+        try {
+          await execFileAsync('git', ['checkout', '--', 'package.json', lockfileName], { cwd: project.path, timeout: 30000 })
+        } catch { /* ignore revert errors */ }
+        return NextResponse.json({ error: `Commit/push failed: ${commitErr instanceof Error ? commitErr.message : String(commitErr)}` }, { status: 500 })
       }
     } else if (action === 'force_major') {
       if (!targetVersion) {
@@ -136,14 +172,21 @@ export async function POST(
       writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n')
       // Do NOT commit — leave dirty for human review
     } else if (action === 'accepted_risk') {
+      let expiryWarning: string | undefined
       if (expiresAt) {
-        record.expiresAt = expiresAt
         const maxDate = new Date()
         maxDate.setDate(maxDate.getDate() + escalationCfg.acceptedRiskMaxDays)
         if (new Date(expiresAt) > maxDate) {
           record.expiresAt = maxDate.toISOString()
+          expiryWarning = `expiresAt clamped to maximum allowed value (${escalationCfg.acceptedRiskMaxDays} days)`
+        } else {
+          record.expiresAt = expiresAt
         }
       }
+
+      addEscalation(record)
+
+      return NextResponse.json({ success: true, record, ...(expiryWarning && { warning: expiryWarning }) })
     }
 
     addEscalation(record)

--- a/src/app/api/projects/[id]/propagate-branches/route.ts
+++ b/src/app/api/projects/[id]/propagate-branches/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getProject, loadConfig } from '@/lib/config';
+import { propagateBranch, DEFAULT_PROPAGATION_CONFIG } from '@/lib/branch-propagator';
+import { parseGitHubRemote } from '@/lib/dependabot-detector';
+import type { BranchSyncStatus, PropagationConfig } from '@/lib/types';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const project = getProject(id);
+
+  if (!project) {
+    return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+  }
+
+  const body = await request.json().catch(() => null);
+  if (!body || !Array.isArray(body.branches) || body.branches.length === 0) {
+    return NextResponse.json({ error: 'branches array required' }, { status: 400 });
+  }
+
+  const branches = body.branches as string[];
+  const openPROverride: boolean | undefined =
+    typeof body.openPR === 'boolean' ? body.openPR : undefined;
+
+  const globalConfig = loadConfig();
+  const token = globalConfig.settings?.integrations?.github?.token ?? null;
+
+  const propagationConfig: PropagationConfig = {
+    ...DEFAULT_PROPAGATION_CONFIG,
+    ...project.propagation,
+    ...(openPROverride !== undefined ? { openPR: openPROverride } : {}),
+  };
+
+  // Resolve owner/repo
+  let owner = project.github?.owner ?? null;
+  let repo = project.github?.repo ?? null;
+  if (!owner || !repo) {
+    const remote = await parseGitHubRemote(project.path);
+    owner = remote.owner;
+    repo = remote.repo;
+  }
+
+  if (propagationConfig.openPR && (!owner || !repo)) {
+    return NextResponse.json(
+      { error: 'Could not determine GitHub owner/repo — configure project.github or ensure git remote points to GitHub' },
+      { status: 422 }
+    );
+  }
+
+  const results: BranchSyncStatus[] = [];
+  const skipped: string[] = [];
+
+  for (const branch of branches) {
+    const result = await propagateBranch(
+      project.path,
+      branch,
+      propagationConfig,
+      owner ?? '',
+      repo ?? '',
+      token
+    );
+    if (result.status === 'synced') {
+      skipped.push(branch);
+    } else {
+      results.push(result);
+    }
+  }
+
+  return NextResponse.json({ results, skipped });
+}

--- a/src/app/api/projects/[id]/update/route.ts
+++ b/src/app/api/projects/[id]/update/route.ts
@@ -496,8 +496,9 @@ export async function POST(
               const pkgJsonPath = join(cwd, 'node_modules', pkg.name, 'package.json');
               if (existsSync(pkgJsonPath)) {
                 const installed = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
-                if (installed.version === pkg.fromVersion) {
-                  // Version didn't change — install silently failed
+                const isFloatingTarget = /^(latest|next|canary)$/.test(pkg.targetVersion);
+                if (installed.version === pkg.fromVersion && !isFloatingTarget) {
+                  // Version didn't change and we had a pinned target — install silently failed
                   verified = false;
                   logger.warn('patches', 'version_unchanged', `${pkg.name} still at ${installed.version} after install`, {
                     projectId: id,

--- a/src/app/patches/page.tsx
+++ b/src/app/patches/page.tsx
@@ -187,7 +187,7 @@ export default function PatchesPage() {
     };
   }, []);
 
-  const handleEscalateSuccess = useCallback((_item: PatchQueueItem) => {
+  const handleEscalateSuccess = useCallback(() => {
     setEscalateModalOpen(false);
     setEscalateItem(null);
     fetchPatches(true);
@@ -1281,7 +1281,7 @@ export default function PatchesPage() {
                         <DependabotPanel projectId={group.projectId} />
                         {/* Show escalation rows for fixAvailable: false items */}
                         {group.patches.filter(p => p.fixAvailable === false).map((item) => (
-                          <div key={`${item.projectId}-${item.package}`} className="px-3 py-2 border-t border-orange-500/10">
+                          <div key={getItemKey(item)} className="px-3 py-2 border-t border-orange-500/10">
                             <div className="flex items-center justify-between">
                               <div className="flex items-center gap-2">
                                 <SeverityBadge type={item.type} severity={item.severity} />
@@ -1333,7 +1333,7 @@ export default function PatchesPage() {
                         })}
                         {/* Pending Major Bump banners */}
                         {group.patches.filter(p => p.escalationStatus === 'force_major_pending').map(item => (
-                          <div key={`major-banner-${item.package}`} className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-3 flex items-center justify-between">
+                          <div key={`major-banner-${getItemKey(item)}`} className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-3 flex items-center justify-between">
                             <div className="flex items-center gap-2 text-sm">
                               <AlertTriangle className="h-4 w-4 text-amber-400" />
                               <span className="text-amber-300 font-medium">Pending Major Bump:</span>

--- a/src/app/patches/page.tsx
+++ b/src/app/patches/page.tsx
@@ -1103,9 +1103,9 @@ export default function PatchesPage() {
                     <div className="flex items-center gap-3 flex-1">
                       <button
                         className="flex items-center gap-3"
-                        onClick={() => group.patches.length > 0 && toggleProjectExpanded(group.projectId)}
+                        onClick={() => (group.patches.length > 0 || dependabotMap[group.projectId]) && toggleProjectExpanded(group.projectId)}
                       >
-                        {group.patches.length > 0 ? (
+                        {group.patches.length > 0 || dependabotMap[group.projectId] ? (
                           expandedProjects.has(group.projectId) ? (
                             <ChevronDown className="h-4 w-4 text-zinc-500" />
                           ) : (
@@ -1123,7 +1123,11 @@ export default function PatchesPage() {
                         >
                           <ExternalLink className="h-3.5 w-3.5" />
                         </Link>
-                        {group.patches.length > 0 ? (
+                        {dependabotMap[group.projectId] ? (
+                          <Badge variant="outline" className="text-xs border-orange-500/30 text-orange-400 bg-orange-500/10">
+                            Dependabot
+                          </Badge>
+                        ) : group.patches.length > 0 ? (
                           <Badge variant="outline" className="text-xs border-zinc-700 text-zinc-500">
                             {group.patches.length} update{group.patches.length !== 1 ? 's' : ''}
                           </Badge>
@@ -1133,8 +1137,8 @@ export default function PatchesPage() {
                           </Badge>
                         )}
                       </button>
-                      {/* Select All / Deselect All - only show when there are patches */}
-                      {group.patches.length > 0 && (
+                      {/* Select All / Deselect All - only show when there are patches and not Dependabot-managed */}
+                      {group.patches.length > 0 && !dependabotMap[group.projectId] && (
                         <Button
                           variant="ghost"
                           size="sm"

--- a/src/app/patches/page.tsx
+++ b/src/app/patches/page.tsx
@@ -6,11 +6,13 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
 import { PatchesSidebar, type UpdateResult, type UpdateStatus } from '@/components/patches-sidebar';
-import { RefreshCw, Shield, Package, ArrowUp, List, FolderTree, ChevronDown, ChevronRight, AlertTriangle, Link as LinkIcon, PauseCircle, PlayCircle, ExternalLink, HelpCircle, Wrench } from 'lucide-react';
+import { RefreshCw, Shield, Package, ArrowUp, List, FolderTree, ChevronDown, ChevronRight, AlertTriangle, Link as LinkIcon, PauseCircle, PlayCircle, ExternalLink, HelpCircle, Wrench, Siren } from 'lucide-react';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
 import type { PatchQueueItem, PatchSummary } from '@/lib/types';
 import { DependabotPanel } from '@/components/detail-sections/dependabot-panel';
+import { EscalateModal } from '@/components/escalate-modal';
+import { AcceptedRiskPanel } from '@/components/accepted-risk-panel';
 import { generatePatchCommitMessage, type UpdatedPackage } from '@/lib/patch-commit-message';
 import { GitCommit, Upload, Pencil, X } from 'lucide-react';
 import { Textarea } from '@/components/ui/textarea';
@@ -114,6 +116,13 @@ export default function PatchesPage() {
   const eventSourceRef = useRef<EventSource | null>(null);
   const [resolvingProjects, setResolvingProjects] = useState<Set<string>>(new Set());
   const [dependabotMap, setDependabotMap] = useState<Record<string, boolean>>({});
+  const [escalateItem, setEscalateItem] = useState<PatchQueueItem | null>(null);
+  const [escalateModalOpen, setEscalateModalOpen] = useState(false);
+
+  const handleEscalate = useCallback((item: PatchQueueItem) => {
+    setEscalateItem(item);
+    setEscalateModalOpen(true);
+  }, []);
 
   const fetchPatches = useCallback((bustCache = false) => {
     // Close any existing connection
@@ -177,6 +186,12 @@ export default function PatchesPage() {
       eventSourceRef.current = null;
     };
   }, []);
+
+  const handleEscalateSuccess = useCallback((_item: PatchQueueItem) => {
+    setEscalateModalOpen(false);
+    setEscalateItem(null);
+    fetchPatches(true);
+  }, [fetchPatches]);
 
   // Fetch persisted patch history
   const fetchHistory = useCallback(async () => {
@@ -1071,6 +1086,7 @@ export default function PatchesPage() {
                     onToggle={toggleSelection}
                     onHold={handleHold}
                     showProject={true}
+                    onEscalate={handleEscalate}
                   />
                 );
               })}
@@ -1263,6 +1279,35 @@ export default function PatchesPage() {
                           <span className="text-xs text-zinc-500">— manual patching disabled</span>
                         </div>
                         <DependabotPanel projectId={group.projectId} />
+                        {/* Show escalation rows for fixAvailable: false items */}
+                        {group.patches.filter(p => p.fixAvailable === false).map((item) => (
+                          <div key={`${item.projectId}-${item.package}`} className="px-3 py-2 border-t border-orange-500/10">
+                            <div className="flex items-center justify-between">
+                              <div className="flex items-center gap-2">
+                                <SeverityBadge type={item.type} severity={item.severity} />
+                                <span className="font-mono text-sm text-zinc-300">{item.package}</span>
+                                {item.escalationStatus === 'accepted_risk_expired' && (
+                                  <Badge variant="outline" className="text-xs bg-red-500/10 border-red-500/30 text-red-400">Expired</Badge>
+                                )}
+                              </div>
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                className="h-7 text-xs border-amber-500/30 text-amber-400 hover:bg-amber-500/10 hover:text-amber-300"
+                                onClick={() => handleEscalate(item)}
+                              >
+                                <Siren className="h-3 w-3 mr-1" />
+                                Escalate
+                              </Button>
+                            </div>
+                          </div>
+                        ))}
+                        {/* Accepted Risk Panel for Dependabot projects */}
+                        <AcceptedRiskPanel
+                          projectId={group.projectId}
+                          items={group.patches}
+                          onReverse={(_item: PatchQueueItem) => fetchPatches(true)}
+                        />
                       </div>
                     ) : (
                       <div className="p-2 space-y-2 bg-zinc-950">
@@ -1279,9 +1324,30 @@ export default function PatchesPage() {
                               onToggle={toggleSelection}
                               onHold={handleHold}
                               showProject={false}
+                              onEscalate={handleEscalate}
                             />
                           );
                         })}
+                        {/* Pending Major Bump banners */}
+                        {group.patches.filter(p => p.escalationStatus === 'force_major_pending').map(item => (
+                          <div key={`major-banner-${item.package}`} className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-3 flex items-center justify-between">
+                            <div className="flex items-center gap-2 text-sm">
+                              <AlertTriangle className="h-4 w-4 text-amber-400" />
+                              <span className="text-amber-300 font-medium">Pending Major Bump:</span>
+                              <span className="font-mono text-zinc-300">{item.package}</span>
+                              {item.currentVersion && item.targetVersion && (
+                                <span className="text-zinc-500 text-xs">{item.currentVersion} → {item.targetVersion}</span>
+                              )}
+                            </div>
+                            <span className="text-xs text-zinc-500">Manual review required before commit</span>
+                          </div>
+                        ))}
+                        {/* Accepted Risk Panel */}
+                        <AcceptedRiskPanel
+                          projectId={group.projectId}
+                          items={group.patches}
+                          onReverse={(_item: PatchQueueItem) => fetchPatches(true)}
+                        />
                       </div>
                     )
                   )}
@@ -1298,6 +1364,15 @@ export default function PatchesPage() {
         updateStatus={updateStatus}
         recentUpdates={recentUpdates}
       />
+
+      {escalateItem && (
+        <EscalateModal
+          item={escalateItem}
+          open={escalateModalOpen}
+          onClose={() => { setEscalateModalOpen(false); setEscalateItem(null); }}
+          onSuccess={handleEscalateSuccess}
+        />
+      )}
     </>
   );
 }
@@ -1309,9 +1384,10 @@ interface PatchRowProps {
   onToggle: (key: string) => void;
   onHold: (projectId: string, packageName: string, hold: boolean) => void;
   showProject: boolean;
+  onEscalate?: (item: PatchQueueItem) => void;
 }
 
-function PatchRow({ item, itemKey, isSelected, onToggle, onHold, showProject }: PatchRowProps) {
+function PatchRow({ item, itemKey, isSelected, onToggle, onHold, showProject, onEscalate }: PatchRowProps) {
   const [showDetails, setShowDetails] = useState(false);
   const isTransitive = item.isDirect === false;
   const isHeld = item.isHeld === true;
@@ -1391,6 +1467,17 @@ function PatchRow({ item, itemKey, isSelected, onToggle, onHold, showProject }: 
                 {item.cves.length} CVE{item.cves.length !== 1 ? 's' : ''}
               </Badge>
             )}
+            {item.escalationStatus === 'force_override_pending' && (
+              <Badge variant="outline" className="text-xs bg-amber-500/10 border-amber-500/30 text-amber-400">
+                <Siren className="h-3 w-3 mr-1" />
+                Escalated
+              </Badge>
+            )}
+            {item.escalationStatus === 'accepted_risk_expired' && (
+              <Badge variant="outline" className="text-xs bg-red-500/10 border-red-500/30 text-red-400">
+                Expired
+              </Badge>
+            )}
           </div>
           {item.title && (
             <p className="text-sm text-zinc-500 truncate mt-1">{item.title}</p>
@@ -1441,6 +1528,19 @@ function PatchRow({ item, itemKey, isSelected, onToggle, onHold, showProject }: 
         >
           <HelpCircle className="h-4 w-4" />
         </Button>
+
+        {/* Escalate button — shown for fixAvailable: false items */}
+        {item.fixAvailable === false && !isHeld && onEscalate && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={(e) => { e.stopPropagation(); onEscalate(item); }}
+            className="h-8 px-2 text-amber-500 hover:text-amber-300 hover:bg-amber-500/10"
+            title="Escalate this vulnerability"
+          >
+            <Siren className="h-4 w-4" />
+          </Button>
+        )}
 
         {/* Hold/Unhold button */}
         <Button

--- a/src/app/patches/page.tsx
+++ b/src/app/patches/page.tsx
@@ -10,6 +10,7 @@ import { RefreshCw, Shield, Package, ArrowUp, List, FolderTree, ChevronDown, Che
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
 import type { PatchQueueItem, PatchSummary } from '@/lib/types';
+import { DependabotPanel } from '@/components/detail-sections/dependabot-panel';
 import { generatePatchCommitMessage, type UpdatedPackage } from '@/lib/patch-commit-message';
 import { GitCommit, Upload, Pencil, X } from 'lucide-react';
 import { Textarea } from '@/components/ui/textarea';
@@ -112,6 +113,7 @@ export default function PatchesPage() {
   const [scanProgress, setScanProgress] = useState<{ scanned: number; total: number; currentProject: string } | null>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
   const [resolvingProjects, setResolvingProjects] = useState<Set<string>>(new Set());
+  const [dependabotMap, setDependabotMap] = useState<Record<string, boolean>>({});
 
   const fetchPatches = useCallback((bustCache = false) => {
     // Close any existing connection
@@ -289,6 +291,23 @@ export default function PatchesPage() {
 
     fetchAllGitStatuses();
   }, [data, fetchProjectGitStatus]);
+
+  // Fetch dependabot status for all projects once data loads
+  useEffect(() => {
+    if (!data) return;
+    const projectIds = Object.keys(data.projectNames);
+    if (!projectIds.length) return;
+    Promise.all(
+      projectIds.map((id) =>
+        fetch(`/api/projects/${id}/dependabot`)
+          .then((r) => r.json())
+          .then((result) => [id, result.managed] as const)
+          .catch(() => [id, false] as const)
+      )
+    ).then((results) => {
+      setDependabotMap(Object.fromEntries(results));
+    });
+  }, [data]);
 
   // Set pending commit for a project after updates
   const setPendingCommit = useCallback((
@@ -1237,24 +1256,34 @@ export default function PatchesPage() {
 
                   {/* Project Patches */}
                   {expandedProjects.has(group.projectId) && (
-                    <div className="p-2 space-y-2 bg-zinc-950">
-                      {group.patches.map((item) => {
-                        const key = getItemKey(item);
-                        const isSelected = selectedPackages.has(key);
+                    dependabotMap[group.projectId] ? (
+                      <div className="rounded-lg border border-orange-500/20 bg-orange-500/5 p-1 m-2">
+                        <div className="flex items-center gap-2 px-3 py-2 border-b border-orange-500/10">
+                          <span className="text-xs font-medium text-orange-400">Dependabot Managed</span>
+                          <span className="text-xs text-zinc-500">— manual patching disabled</span>
+                        </div>
+                        <DependabotPanel projectId={group.projectId} />
+                      </div>
+                    ) : (
+                      <div className="p-2 space-y-2 bg-zinc-950">
+                        {group.patches.map((item) => {
+                          const key = getItemKey(item);
+                          const isSelected = selectedPackages.has(key);
 
-                        return (
-                          <PatchRow
-                            key={key}
-                            item={item}
-                            itemKey={key}
-                            isSelected={isSelected}
-                            onToggle={toggleSelection}
-                            onHold={handleHold}
-                            showProject={false}
-                          />
-                        );
-                      })}
-                    </div>
+                          return (
+                            <PatchRow
+                              key={key}
+                              item={item}
+                              itemKey={key}
+                              isSelected={isSelected}
+                              onToggle={toggleSelection}
+                              onHold={handleHold}
+                              showProject={false}
+                            />
+                          );
+                        })}
+                      </div>
+                    )
                   )}
                 </div>
               );

--- a/src/app/patches/page.tsx
+++ b/src/app/patches/page.tsx
@@ -1305,7 +1305,10 @@ export default function PatchesPage() {
                         {/* Accepted Risk Panel for Dependabot projects */}
                         <AcceptedRiskPanel
                           projectId={group.projectId}
-                          items={group.patches}
+                          items={group.patches.filter(p =>
+                            p.escalationStatus === 'accepted_risk' ||
+                            p.escalationStatus === 'accepted_risk_expired'
+                          )}
                           onReverse={(_item: PatchQueueItem) => fetchPatches(true)}
                         />
                       </div>
@@ -1339,13 +1342,22 @@ export default function PatchesPage() {
                                 <span className="text-zinc-500 text-xs">{item.currentVersion} → {item.targetVersion}</span>
                               )}
                             </div>
-                            <span className="text-xs text-zinc-500">Manual review required before commit</span>
+                            <Link
+                              href={`/projects/${group.projectId}`}
+                              className="text-xs text-amber-400 hover:text-amber-300 underline"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              Review & Commit →
+                            </Link>
                           </div>
                         ))}
                         {/* Accepted Risk Panel */}
                         <AcceptedRiskPanel
                           projectId={group.projectId}
-                          items={group.patches}
+                          items={group.patches.filter(p =>
+                            p.escalationStatus === 'accepted_risk' ||
+                            p.escalationStatus === 'accepted_risk_expired'
+                          )}
                           onReverse={(_item: PatchQueueItem) => fetchPatches(true)}
                         />
                       </div>

--- a/src/components/accepted-risk-panel.tsx
+++ b/src/components/accepted-risk-panel.tsx
@@ -8,12 +8,11 @@ import type { PatchQueueItem } from '@/lib/types'
 
 interface AcceptedRiskPanelProps {
   projectId: string
-  projectName: string
   items: PatchQueueItem[]   // items where escalationStatus === 'accepted_risk' or 'accepted_risk_expired'
   onReverse: (item: PatchQueueItem) => void
 }
 
-export function AcceptedRiskPanel({ projectId, projectName, items, onReverse }: AcceptedRiskPanelProps) {
+export function AcceptedRiskPanel({ projectId, items, onReverse }: AcceptedRiskPanelProps) {
   const [expanded, setExpanded] = useState(false)
   const [reversing, setReversing] = useState<string | null>(null)
 
@@ -26,12 +25,18 @@ export function AcceptedRiskPanel({ projectId, projectName, items, onReverse }: 
     if (!item.escalationId) return
     setReversing(item.escalationId)
     try {
-      await fetch(`/api/projects/${item.projectId}/escalate`, {
+      const res = await fetch(`/api/projects/${item.projectId}/escalate`, {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ escalationId: item.escalationId }),
       })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error((data as { error?: string }).error ?? 'Failed to reverse escalation')
+      }
       onReverse(item)
+    } catch (err) {
+      console.error('Reverse escalation failed:', err)
     } finally {
       setReversing(null)
     }
@@ -94,7 +99,7 @@ export function AcceptedRiskPanel({ projectId, projectName, items, onReverse }: 
                   variant="ghost"
                   size="sm"
                   className="h-6 text-xs shrink-0"
-                  disabled={reversing === item.escalationId}
+                  disabled={!item.escalationId || reversing === item.escalationId}
                   onClick={() => handleReverse(item)}
                 >
                   {reversing === item.escalationId ? '…' : 'Reverse'}

--- a/src/components/accepted-risk-panel.tsx
+++ b/src/components/accepted-risk-panel.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import { useState } from 'react'
+import { ChevronDown, ChevronRight, Clock, AlertTriangle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import type { PatchQueueItem } from '@/lib/types'
+
+interface AcceptedRiskPanelProps {
+  projectId: string
+  projectName: string
+  items: PatchQueueItem[]   // items where escalationStatus === 'accepted_risk' or 'accepted_risk_expired'
+  onReverse: (item: PatchQueueItem) => void
+}
+
+export function AcceptedRiskPanel({ projectId, projectName, items, onReverse }: AcceptedRiskPanelProps) {
+  const [expanded, setExpanded] = useState(false)
+  const [reversing, setReversing] = useState<string | null>(null)
+
+  if (items.length === 0) return null
+
+  const expired = items.filter(i => i.escalationStatus === 'accepted_risk_expired')
+  const active = items.filter(i => i.escalationStatus === 'accepted_risk')
+
+  async function handleReverse(item: PatchQueueItem) {
+    if (!item.escalationId) return
+    setReversing(item.escalationId)
+    try {
+      await fetch(`/api/projects/${item.projectId}/escalate`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ escalationId: item.escalationId }),
+      })
+      onReverse(item)
+    } finally {
+      setReversing(null)
+    }
+  }
+
+  function daysUntilExpiry(expiresAt: string) {
+    const diff = new Date(expiresAt).getTime() - Date.now()
+    return Math.ceil(diff / (1000 * 60 * 60 * 24))
+  }
+
+  return (
+    <div className="mt-2 rounded-lg border border-orange-200 dark:border-orange-900 bg-orange-50/50 dark:bg-orange-950/20">
+      <button
+        className="w-full flex items-center gap-2 px-3 py-2 text-sm font-medium text-orange-700 dark:text-orange-400"
+        onClick={() => setExpanded(e => !e)}
+      >
+        {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        Accepted Risk ({items.length})
+        {expired.length > 0 && (
+          <Badge variant="destructive" className="ml-1 text-xs h-4">
+            {expired.length} expired
+          </Badge>
+        )}
+      </button>
+
+      {expanded && (
+        <div className="px-3 pb-3 space-y-2">
+          {/* Expired items first, then active */}
+          {[...expired, ...active].map(item => {
+            const isExpired = item.escalationStatus === 'accepted_risk_expired'
+            const days = item.escalationExpiresAt ? daysUntilExpiry(item.escalationExpiresAt) : null
+
+            return (
+              <div
+                key={item.escalationId ?? item.package}
+                className={`flex items-start justify-between gap-3 rounded p-2 text-sm ${
+                  isExpired
+                    ? 'bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800'
+                    : 'bg-white dark:bg-gray-900/50'
+                }`}
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="font-mono text-xs font-medium">{item.package}</span>
+                    {isExpired && (
+                      <Badge variant="destructive" className="text-xs h-4">Expired</Badge>
+                    )}
+                    {!isExpired && days !== null && (
+                      <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                        <Clock className="h-3 w-3" />
+                        Expires in {days}d
+                      </span>
+                    )}
+                  </div>
+                  {item.escalationReason && (
+                    <p className="text-xs text-muted-foreground mt-0.5 truncate">{item.escalationReason}</p>
+                  )}
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 text-xs shrink-0"
+                  disabled={reversing === item.escalationId}
+                  onClick={() => handleReverse(item)}
+                >
+                  {reversing === item.escalationId ? '…' : 'Reverse'}
+                </Button>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/branch-propagate-modal.tsx
+++ b/src/components/branch-propagate-modal.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
+import { cn } from '@/lib/utils';
+import type { BranchSyncStatus, PropagationConfig } from '@/lib/types';
+
+interface BranchPropagateModalProps {
+  projectId: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function BranchPropagateModal({
+  projectId,
+  open,
+  onClose,
+}: BranchPropagateModalProps) {
+  const [loading, setLoading] = useState(true);
+  const [branches, setBranches] = useState<BranchSyncStatus[]>([]);
+  const [config, setConfig] = useState<PropagationConfig | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [openPR, setOpenPR] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [results, setResults] = useState<BranchSyncStatus[] | null>(null);
+  const [skipped, setSkipped] = useState<string[]>([]);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    setResults(null);
+    setSkipped([]);
+    setFetchError(null);
+
+    fetch(`/api/projects/${projectId}/branch-sync`)
+      .then((r) => r.json())
+      .then((data: { branches: BranchSyncStatus[]; config: PropagationConfig; error?: string }) => {
+        if (data.error) {
+          setFetchError(data.error);
+          setLoading(false);
+          return;
+        }
+        setBranches(data.branches);
+        setConfig(data.config);
+        setOpenPR(data.config.openPR);
+        setSelected(new Set(data.branches.filter((b) => b.status === 'out_of_sync').map((b) => b.branch)));
+        setLoading(false);
+      })
+      .catch((err) => {
+        setFetchError(err instanceof Error ? err.message : 'Failed to load branch status');
+        setLoading(false);
+      });
+  }, [open, projectId]);
+
+  const toggleBranch = (branch: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(branch)) next.delete(branch);
+      else next.add(branch);
+      return next;
+    });
+  };
+
+  const handleSubmit = async () => {
+    if (selected.size === 0) return;
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/projects/${projectId}/propagate-branches`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ branches: Array.from(selected), openPR }),
+      });
+      const data = await res.json();
+      setResults(data.results ?? []);
+      setSkipped(data.skipped ?? []);
+    } catch (err) {
+      setResults([{
+        branch: 'unknown',
+        status: 'conflict',
+        error: err instanceof Error ? err.message : 'Request failed',
+      }]);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const outOfSync = branches.filter((b) => b.status === 'out_of_sync');
+  const synced = branches.filter((b) => b.status === 'synced');
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-lg bg-zinc-900 border-zinc-700">
+        <DialogHeader>
+          <DialogTitle className="text-zinc-100">Propagate Branch Dependencies</DialogTitle>
+        </DialogHeader>
+
+        {loading && (
+          <div className="flex items-center gap-2 text-sm text-zinc-400 py-4">
+            <span className="animate-spin">⟳</span> Checking branch sync status…
+          </div>
+        )}
+
+        {fetchError && (
+          <div className="rounded-md bg-red-500/10 border border-red-500/20 px-3 py-2 text-sm text-red-400">
+            {fetchError}
+          </div>
+        )}
+
+        {!loading && !fetchError && results === null && (
+          <div className="space-y-4">
+            {outOfSync.length === 0 ? (
+              <p className="text-sm text-zinc-400">All active branches are in sync with main.</p>
+            ) : (
+              <>
+                <p className="text-sm text-zinc-400">
+                  Select branches to sync with main&apos;s <code className="text-zinc-300">package.json</code>:
+                </p>
+                <div className="space-y-2">
+                  {outOfSync.map((b) => (
+                    <label
+                      key={b.branch}
+                      className={cn(
+                        'flex items-center gap-3 rounded-lg border p-3 cursor-pointer',
+                        selected.has(b.branch)
+                          ? 'border-amber-500/30 bg-amber-500/5'
+                          : 'border-zinc-700 bg-zinc-800/50'
+                      )}
+                    >
+                      <Checkbox
+                        checked={selected.has(b.branch)}
+                        onCheckedChange={() => toggleBranch(b.branch)}
+                      />
+                      <span className="font-mono text-sm text-zinc-200">{b.branch}</span>
+                      <Badge variant="outline" className="ml-auto text-xs border-amber-500/30 text-amber-400 bg-amber-500/10">
+                        Out of sync
+                      </Badge>
+                    </label>
+                  ))}
+                </div>
+
+                {synced.length > 0 && (
+                  <p className="text-xs text-zinc-500">
+                    {synced.length} branch{synced.length !== 1 ? 'es' : ''} already in sync: {synced.map((b) => b.branch).join(', ')}
+                  </p>
+                )}
+
+                <div className="rounded-lg border border-zinc-700 p-3 space-y-2">
+                  <p className="text-xs font-medium text-zinc-300">Delivery mode</p>
+                  <div className="flex gap-3">
+                    <label className={cn('flex items-center gap-2 text-sm cursor-pointer', openPR ? 'text-zinc-100' : 'text-zinc-500')}>
+                      <input
+                        type="radio"
+                        checked={openPR}
+                        onChange={() => setOpenPR(true)}
+                        className="accent-amber-500"
+                      />
+                      Open PR per branch
+                    </label>
+                    <label className={cn('flex items-center gap-2 text-sm cursor-pointer', !openPR ? 'text-zinc-100' : 'text-zinc-500')}>
+                      <input
+                        type="radio"
+                        checked={!openPR}
+                        onChange={() => setOpenPR(false)}
+                        className="accent-amber-500"
+                      />
+                      Push directly
+                    </label>
+                  </div>
+                  {openPR && (
+                    <p className="text-xs text-zinc-500">Requires GitHub token in Settings.</p>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        {results !== null && (
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-zinc-300">Results</p>
+            {results.map((r) => (
+              <div
+                key={r.branch}
+                className={cn(
+                  'flex items-start gap-3 rounded-lg border p-3 text-sm',
+                  r.status === 'propagated'
+                    ? 'border-green-500/20 bg-green-500/5'
+                    : 'border-red-500/20 bg-red-500/5'
+                )}
+              >
+                <span>{r.status === 'propagated' ? '✅' : '⚠️'}</span>
+                <div className="flex-1 min-w-0">
+                  <span className="font-mono text-zinc-200">{r.branch}</span>
+                  {r.status === 'propagated' && r.prUrl && (
+                    <a
+                      href={r.prUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="block text-xs text-amber-400 hover:text-amber-300 underline mt-1"
+                    >
+                      View PR →
+                    </a>
+                  )}
+                  {r.status === 'propagated' && !r.prUrl && (
+                    <p className="text-xs text-green-400 mt-1">Pushed directly to branch</p>
+                  )}
+                  {r.status === 'conflict' && (
+                    <p className="text-xs text-red-400 mt-1">{r.error}</p>
+                  )}
+                </div>
+              </div>
+            ))}
+            {skipped.length > 0 && (
+              <p className="text-xs text-zinc-500">
+                Skipped (already in sync): {skipped.join(', ')}
+              </p>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          {results === null ? (
+            <>
+              <Button variant="ghost" onClick={onClose} className="text-zinc-400">
+                Cancel
+              </Button>
+              <Button
+                onClick={handleSubmit}
+                disabled={submitting || selected.size === 0 || loading}
+                className="bg-amber-600 hover:bg-amber-500 text-white"
+              >
+                {submitting ? 'Propagating…' : `Propagate ${selected.size > 0 ? `(${selected.size})` : ''}`}
+              </Button>
+            </>
+          ) : (
+            <Button onClick={onClose} className="bg-zinc-700 hover:bg-zinc-600 text-zinc-100">
+              Done
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/detail-sections/dependabot-panel.tsx
+++ b/src/components/detail-sections/dependabot-panel.tsx
@@ -2,6 +2,10 @@
 
 import { useEffect, useState } from 'react';
 import type { DependabotConfig, DependabotPR } from '@/lib/types';
+import { BranchPropagateModal } from '@/components/branch-propagate-modal';
+import { AlertTriangle, GitBranch } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { BranchSyncStatus } from '@/lib/types';
 
 interface DependabotPanelProps {
   projectId: string;
@@ -10,6 +14,8 @@ interface DependabotPanelProps {
 export function DependabotPanel({ projectId }: DependabotPanelProps) {
   const [config, setConfig] = useState<DependabotConfig | null>(null);
   const [loading, setLoading] = useState(true);
+  const [outOfSyncBranches, setOutOfSyncBranches] = useState<string[]>([]);
+  const [propagateOpen, setPropagateOpen] = useState(false);
 
   useEffect(() => {
     fetch(`/api/projects/${projectId}/dependabot`)
@@ -19,6 +25,18 @@ export function DependabotPanel({ projectId }: DependabotPanelProps) {
         setLoading(false);
       })
       .catch(() => setLoading(false));
+  }, [projectId]);
+
+  useEffect(() => {
+    fetch(`/api/projects/${projectId}/branch-sync`)
+      .then((r) => r.json())
+      .then((data: { branches?: BranchSyncStatus[] }) => {
+        const oosNames = (data.branches ?? [])
+          .filter((b) => b.status === 'out_of_sync')
+          .map((b) => b.branch);
+        setOutOfSyncBranches(oosNames);
+      })
+      .catch(() => {});
   }, [projectId]);
 
   if (loading) {
@@ -50,6 +68,27 @@ export function DependabotPanel({ projectId }: DependabotPanelProps) {
         </a>
       </div>
 
+      {outOfSyncBranches.length > 0 && (
+        <div className="rounded-md bg-amber-500/10 border border-amber-500/20 px-3 py-2 flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-xs text-amber-400">
+            <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+            <span>
+              <strong>{outOfSyncBranches.length}</strong> branch{outOfSyncBranches.length !== 1 ? 'es' : ''} out of sync with main
+              <span className="text-amber-500/70 ml-1">— {outOfSyncBranches.join(', ')}</span>
+            </span>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 text-xs text-amber-400 hover:text-amber-300 hover:bg-amber-500/10 shrink-0"
+            onClick={() => setPropagateOpen(true)}
+          >
+            <GitBranch className="h-3 w-3 mr-1" />
+            Propagate →
+          </Button>
+        </div>
+      )}
+
       {config.error && (
         <div className="rounded-md bg-red-500/10 border border-red-500/20 px-3 py-2 text-xs text-red-400">
           {config.error}
@@ -78,6 +117,11 @@ export function DependabotPanel({ projectId }: DependabotPanelProps) {
           Last fetched: {new Date(config.fetchedAt).toLocaleTimeString()}
         </p>
       )}
+      <BranchPropagateModal
+        projectId={projectId}
+        open={propagateOpen}
+        onClose={() => setPropagateOpen(false)}
+      />
     </div>
   );
 }

--- a/src/components/detail-sections/dependabot-panel.tsx
+++ b/src/components/detail-sections/dependabot-panel.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { DependabotConfig, DependabotPR } from '@/lib/types';
+
+interface DependabotPanelProps {
+  projectId: string;
+}
+
+export function DependabotPanel({ projectId }: DependabotPanelProps) {
+  const [config, setConfig] = useState<DependabotConfig | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`/api/projects/${projectId}/dependabot`)
+      .then((r) => r.json())
+      .then((data) => {
+        setConfig(data);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [projectId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-zinc-400 p-4">
+        <span className="animate-spin">⟳</span> Loading Dependabot status…
+      </div>
+    );
+  }
+
+  if (!config?.managed) return null;
+
+  return (
+    <div className="space-y-4 p-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-zinc-100">Dependabot Managed</h3>
+          <p className="text-xs text-zinc-400 mt-0.5">
+            {config.owner}/{config.repo} · Updates handled via GitHub PRs
+          </p>
+        </div>
+        <a
+          href={`https://github.com/${config.owner}/${config.repo}/pulls?q=is%3Apr+is%3Aopen+author%3Aapp%2Fdependabot`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-orange-400 hover:text-orange-300 underline"
+        >
+          View on GitHub ↗
+        </a>
+      </div>
+
+      {config.error && (
+        <div className="rounded-md bg-red-500/10 border border-red-500/20 px-3 py-2 text-xs text-red-400">
+          {config.error}
+        </div>
+      )}
+
+      {!config.error && config.prs.length === 0 && (
+        <div className="rounded-md bg-zinc-800/50 border border-zinc-700 px-3 py-2 text-xs text-zinc-400">
+          No open Dependabot PRs — all up to date.
+        </div>
+      )}
+
+      {config.prs.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-xs text-zinc-400">{config.prs.length} open PR{config.prs.length !== 1 ? 's' : ''}</p>
+          <ul className="space-y-2">
+            {config.prs.map((pr) => (
+              <PRRow key={pr.number} pr={pr} />
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {config.fetchedAt && (
+        <p className="text-xs text-zinc-600">
+          Last fetched: {new Date(config.fetchedAt).toLocaleTimeString()}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function PRRow({ pr }: { pr: DependabotPR }) {
+  const mergeStatus = pr.mergeable === false
+    ? { label: 'Conflict', color: 'text-red-400 bg-red-500/10 border-red-500/20' }
+    : pr.mergeable === true
+    ? { label: 'Mergeable', color: 'text-green-400 bg-green-500/10 border-green-500/20' }
+    : { label: 'Checking', color: 'text-zinc-400 bg-zinc-800 border-zinc-700' };
+
+  const updateLabel = pr.updateType.replace('version-update:semver-', '');
+
+  return (
+    <li className="flex items-start justify-between gap-3 rounded-md border border-zinc-700/50 bg-zinc-800/40 px-3 py-2">
+      <div className="flex-1 min-w-0">
+        <a
+          href={pr.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-zinc-200 hover:text-white truncate block"
+        >
+          #{pr.number} {pr.title}
+        </a>
+        <div className="flex items-center gap-2 mt-1">
+          {pr.dependencyGroup && (
+            <span className="text-xs text-zinc-500">Group: {pr.dependencyGroup}</span>
+          )}
+          {updateLabel && (
+            <span className="text-xs text-zinc-500 capitalize">{updateLabel}</span>
+          )}
+        </div>
+      </div>
+      <span className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium ${mergeStatus.color}`}>
+        {mergeStatus.label}
+      </span>
+    </li>
+  );
+}

--- a/src/components/escalate-modal.tsx
+++ b/src/components/escalate-modal.tsx
@@ -22,7 +22,7 @@ interface EscalateModalProps {
   item: PatchQueueItem | null
   projectEscalationConfig?: Partial<EscalationConfig>
   onClose: () => void
-  onSuccess: (item: PatchQueueItem) => void
+  onSuccess: () => void
 }
 
 export function EscalateModal({ open, item, projectEscalationConfig, onClose, onSuccess }: EscalateModalProps) {
@@ -76,7 +76,7 @@ export function EscalateModal({ open, item, projectEscalationConfig, onClose, on
       const data = await res.json()
       if (!res.ok) throw new Error(data.error ?? 'Escalation failed')
 
-      onSuccess(item)
+      onSuccess()
       onClose()
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))

--- a/src/components/escalate-modal.tsx
+++ b/src/components/escalate-modal.tsx
@@ -1,0 +1,234 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { Input } from '@/components/ui/input'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { Switch } from '@/components/ui/switch'
+import { AlertTriangle, Zap } from 'lucide-react'
+import type { PatchQueueItem, EscalateAction, EscalationConfig } from '@/lib/types'
+
+interface EscalateModalProps {
+  open: boolean
+  item: PatchQueueItem | null
+  projectEscalationConfig?: Partial<EscalationConfig>
+  onClose: () => void
+  onSuccess: (item: PatchQueueItem) => void
+}
+
+export function EscalateModal({ open, item, projectEscalationConfig, onClose, onSuccess }: EscalateModalProps) {
+  const [action, setAction] = useState<EscalateAction>('force_override')
+  const [reason, setReason] = useState('')
+  const [overrideVersion, setOverrideVersion] = useState(item?.targetVersion ?? '')
+  const [targetVersion, setTargetVersion] = useState(item?.targetVersion ?? '')
+  const [expiresAt, setExpiresAt] = useState('')
+  const [autoCommit, setAutoCommit] = useState(projectEscalationConfig?.autoCommit ?? false)
+  const [autoPush, setAutoPush] = useState(projectEscalationConfig?.autoPush ?? false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const maxDays = projectEscalationConfig?.acceptedRiskMaxDays ?? 90
+  const maxDate = new Date()
+  maxDate.setDate(maxDate.getDate() + maxDays)
+
+  async function submit(emergency = false) {
+    if (!item || !reason.trim()) return
+    setLoading(true)
+    setError(null)
+
+    try {
+      const res = await fetch(`/api/projects/${item.projectId}/escalate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          package: item.package,
+          action,
+          reason: reason.trim(),
+          ...(action === 'force_override' && { overrideVersion, autoCommit, autoPush }),
+          ...(action === 'force_major' && { targetVersion }),
+          ...(action === 'accepted_risk' && expiresAt && { expiresAt }),
+          ...(emergency && { emergency: true }),
+        }),
+      })
+
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error ?? 'Escalation failed')
+
+      onSuccess(item)
+      onClose()
+    } catch (err) {
+      setError(String(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!item) return null
+
+  return (
+    <Dialog open={open} onOpenChange={open => !open && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-amber-500" />
+            Escalate: {item.package}
+          </DialogTitle>
+          {item.url && (
+            <a href={item.url} target="_blank" rel="noopener noreferrer" className="text-xs text-blue-500 hover:underline">
+              View advisory ↗
+            </a>
+          )}
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <RadioGroup value={action} onValueChange={v => setAction(v as EscalateAction)}>
+            {/* Force Override */}
+            <div
+              className={`rounded-lg border p-3 cursor-pointer ${action === 'force_override' ? 'border-blue-500 bg-blue-50 dark:bg-blue-950' : ''}`}
+              onClick={() => setAction('force_override')}
+            >
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="force_override" id="force_override" />
+                <Label htmlFor="force_override" className="font-medium cursor-pointer">Force Override</Label>
+              </div>
+              <p className="text-xs text-muted-foreground mt-1 ml-6">
+                Pin transitive dep via package.json overrides + regenerate lockfile
+              </p>
+              {action === 'force_override' && (
+                <div className="mt-3 ml-6 space-y-3">
+                  <div>
+                    <Label className="text-xs">Pin to version</Label>
+                    <Input
+                      className="mt-1 h-8 text-sm"
+                      value={overrideVersion}
+                      onChange={e => setOverrideVersion(e.target.value)}
+                      placeholder="e.g. 2.17.3"
+                    />
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <Label className="text-xs">Auto-commit</Label>
+                    <Switch checked={autoCommit} onCheckedChange={setAutoCommit} />
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <Label className="text-xs text-muted-foreground">Auto-push (requires auto-commit)</Label>
+                    <Switch checked={autoPush} disabled={!autoCommit} onCheckedChange={setAutoPush} />
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Force Major Bump */}
+            <div
+              className={`rounded-lg border p-3 cursor-pointer ${action === 'force_major' ? 'border-amber-500 bg-amber-50 dark:bg-amber-950' : ''}`}
+              onClick={() => setAction('force_major')}
+            >
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="force_major" id="force_major" />
+                <Label htmlFor="force_major" className="font-medium cursor-pointer">Force Major Bump</Label>
+              </div>
+              <p className="text-xs text-muted-foreground mt-1 ml-6">
+                Updates package.json only. <strong>Never auto-commits.</strong> Review and commit manually.
+              </p>
+              {action === 'force_major' && (
+                <div className="mt-3 ml-6">
+                  <Label className="text-xs">Target version</Label>
+                  <Input
+                    className="mt-1 h-8 text-sm"
+                    value={targetVersion}
+                    onChange={e => setTargetVersion(e.target.value)}
+                    placeholder="e.g. 4.0.0"
+                  />
+                  <p className="text-xs text-amber-600 mt-2">
+                    ⚠ Breaking changes likely. Test thoroughly before merging.
+                  </p>
+                </div>
+              )}
+            </div>
+
+            {/* Accept Risk */}
+            <div
+              className={`rounded-lg border p-3 cursor-pointer ${action === 'accepted_risk' ? 'border-orange-500 bg-orange-50 dark:bg-orange-950' : ''}`}
+              onClick={() => setAction('accepted_risk')}
+            >
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="accepted_risk" id="accepted_risk" />
+                <Label htmlFor="accepted_risk" className="font-medium cursor-pointer">Accept Risk</Label>
+              </div>
+              <p className="text-xs text-muted-foreground mt-1 ml-6">
+                Suppress this vuln from the queue. Max {maxDays} days. Will re-surface on expiry.
+              </p>
+              {action === 'accepted_risk' && (
+                <div className="mt-3 ml-6 space-y-2">
+                  <Label className="text-xs">Expiry date (max {maxDate.toLocaleDateString()})</Label>
+                  <Input
+                    type="date"
+                    className="h-8 text-sm"
+                    max={maxDate.toISOString().split('T')[0]}
+                    value={expiresAt ? expiresAt.split('T')[0] : ''}
+                    onChange={e => setExpiresAt(e.target.value ? new Date(e.target.value).toISOString() : '')}
+                  />
+                </div>
+              )}
+            </div>
+          </RadioGroup>
+
+          {/* Reason — always required */}
+          <div>
+            <Label className="text-sm">
+              Reason <span className="text-red-500">*</span>
+            </Label>
+            <Textarea
+              className="mt-1 text-sm"
+              rows={2}
+              placeholder="Why is this being escalated rather than patched normally?"
+              value={reason}
+              onChange={e => setReason(e.target.value)}
+            />
+          </div>
+
+          {error && (
+            <p className="text-xs text-red-500 bg-red-50 dark:bg-red-950 rounded p-2">{error}</p>
+          )}
+        </div>
+
+        <DialogFooter className="flex items-center justify-between">
+          <div>
+            {action === 'force_override' && (
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={!reason.trim() || !overrideVersion || loading}
+                onClick={() => submit(true)}
+                className="gap-1"
+              >
+                <Zap className="h-3 w-3" />
+                Patch Now
+              </Button>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={onClose} disabled={loading}>
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              disabled={!reason.trim() || loading}
+              onClick={() => submit(false)}
+            >
+              {loading ? 'Working…' : 'Escalate'}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/escalate-modal.tsx
+++ b/src/components/escalate-modal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -36,6 +36,19 @@ export function EscalateModal({ open, item, projectEscalationConfig, onClose, on
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  // Reset field state when the modal opens for a new item
+  useEffect(() => {
+    if (!item) return
+    setAction('force_override')
+    setReason('')
+    setOverrideVersion(item.targetVersion ?? '')
+    setTargetVersion(item.targetVersion ?? '')
+    setExpiresAt('')
+    setAutoCommit(projectEscalationConfig?.autoCommit ?? false)
+    setAutoPush(projectEscalationConfig?.autoPush ?? false)
+    setError(null)
+  }, [item?.package, item?.projectId, open])
+
   const maxDays = projectEscalationConfig?.acceptedRiskMaxDays ?? 90
   const maxDate = new Date()
   maxDate.setDate(maxDate.getDate() + maxDays)
@@ -66,7 +79,7 @@ export function EscalateModal({ open, item, projectEscalationConfig, onClose, on
       onSuccess(item)
       onClose()
     } catch (err) {
-      setError(String(err))
+      setError(err instanceof Error ? err.message : String(err))
     } finally {
       setLoading(false)
     }
@@ -116,7 +129,13 @@ export function EscalateModal({ open, item, projectEscalationConfig, onClose, on
                   </div>
                   <div className="flex items-center justify-between">
                     <Label className="text-xs">Auto-commit</Label>
-                    <Switch checked={autoCommit} onCheckedChange={setAutoCommit} />
+                    <Switch
+                      checked={autoCommit}
+                      onCheckedChange={val => {
+                        setAutoCommit(val)
+                        if (!val) setAutoPush(false)
+                      }}
+                    />
                   </div>
                   <div className="flex items-center justify-between">
                     <Label className="text-xs text-muted-foreground">Auto-push (requires auto-commit)</Label>
@@ -221,7 +240,7 @@ export function EscalateModal({ open, item, projectEscalationConfig, onClose, on
             </Button>
             <Button
               size="sm"
-              disabled={!reason.trim() || loading}
+              disabled={!reason.trim() || (action === 'force_override' && !overrideVersion) || loading}
               onClick={() => submit(false)}
             >
               {loading ? 'Working…' : 'Escalate'}

--- a/src/components/project-card.tsx
+++ b/src/components/project-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -19,6 +19,14 @@ interface ProjectCardProps {
 export function ProjectCard({ project, onStart, onStop, onViewLogs, onClearCache, onDeleteLock }: ProjectCardProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [dependabotManaged, setDependabotManaged] = useState<boolean>(false);
+
+  useEffect(() => {
+    fetch(`/api/projects/${project.id}/dependabot`)
+      .then((r) => r.json())
+      .then((data) => setDependabotManaged(data.managed ?? false))
+      .catch(() => {});
+  }, [project.id]);
 
   const handleToggle = async () => {
     setIsLoading(true);
@@ -89,12 +97,22 @@ export function ProjectCard({ project, onStart, onStop, onViewLogs, onClearCache
         </CardHeader>
         <CardContent className="pt-2 space-y-2">
           <div className="flex items-center justify-between">
-            <Badge
-              variant="secondary"
-              className="bg-zinc-800 text-zinc-400 text-xs"
-            >
-              {project.category}
-            </Badge>
+            <div className="flex items-center gap-2">
+              <Badge
+                variant="secondary"
+                className="bg-zinc-800 text-zinc-400 text-xs"
+              >
+                {project.category}
+              </Badge>
+              {dependabotManaged && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-orange-500/10 px-2 py-0.5 text-xs font-medium text-orange-400 ring-1 ring-orange-500/20">
+                  <svg className="h-3 w-3" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM4.5 7.5a.5.5 0 0 0 0 1h5.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3a.5.5 0 0 0 0-.708l-3-3a.5.5 0 1 0-.708.708L10.293 7.5H4.5Z" />
+                  </svg>
+                  Dependabot
+                </span>
+              )}
+            </div>
             <div className="flex gap-2">
               {isRunning && (
                 <>

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import * as React from "react"
+import { Label as LabelPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import * as React from "react"
+import { CircleIcon } from "lucide-react"
+import { RadioGroup as RadioGroupPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn("grid gap-3", className)}
+      {...props}
+    />
+  )
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        "aspect-square size-4 shrink-0 rounded-full border border-input text-primary shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="relative flex items-center justify-center"
+      >
+        <CircleIcon className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 fill-primary" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+}
+
+export { RadioGroup, RadioGroupItem }

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/src/lib/branch-propagator.ts
+++ b/src/lib/branch-propagator.ts
@@ -1,0 +1,239 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { detectPackageManager } from './patch-scanner';
+import { openPropagationPR } from './github-client';
+import type { BranchSyncStatus, PropagationConfig } from './types';
+
+const execFileAsync = promisify(execFile);
+
+export const DEFAULT_PROPAGATION_CONFIG: PropagationConfig = {
+  activeBranchDays: 30,
+  openPR: true,
+  autoPush: false,
+};
+
+const LOCK_FILES: Record<string, string> = {
+  pnpm: 'pnpm-lock.yaml',
+  npm: 'package-lock.json',
+  yarn: 'yarn.lock',
+};
+
+const INSTALL_CMD: Record<string, string[]> = {
+  pnpm: ['pnpm', 'install', '--no-frozen-lockfile'],
+  npm: ['npm', 'install', '--legacy-peer-deps'],
+  yarn: ['yarn', 'install'],
+};
+
+/**
+ * Lists active remote branches (excluding main/master/HEAD) with a commit
+ * within the last `days` days. Runs `git fetch` first to ensure current data.
+ */
+export async function getActiveBranches(
+  projectPath: string,
+  days: number
+): Promise<string[]> {
+  await execFileAsync('git', ['fetch', 'origin', '--prune'], {
+    cwd: projectPath,
+    timeout: 30000,
+  });
+
+  const { stdout } = await execFileAsync(
+    'git',
+    [
+      'for-each-ref',
+      '--sort=-committerdate',
+      '--format=%(refname:short) %(committerdate:iso-strict)',
+      'refs/remotes/origin/',
+    ],
+    { cwd: projectPath, timeout: 10000 }
+  );
+
+  const SKIP = new Set(['origin/main', 'origin/master', 'origin/HEAD']);
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+  const branches: string[] = [];
+
+  for (const line of stdout.trim().split('\n')) {
+    if (!line.trim()) continue;
+    const spaceIdx = line.indexOf(' ');
+    const refname = line.slice(0, spaceIdx);
+    const date = line.slice(spaceIdx + 1).trim();
+    if (SKIP.has(refname)) continue;
+    if (date >= cutoff) {
+      branches.push(refname.replace('origin/', ''));
+    }
+  }
+
+  return branches;
+}
+
+interface DepSnapshot {
+  dependencies: Record<string, string>;
+  devDependencies: Record<string, string>;
+  overrides: Record<string, string>;
+  pnpmOverrides: Record<string, string>;
+  resolutions: Record<string, string>;
+}
+
+function extractDeps(pkg: Record<string, unknown>): DepSnapshot {
+  const pnpm = (pkg.pnpm ?? {}) as Record<string, unknown>;
+  return {
+    dependencies: (pkg.dependencies ?? {}) as Record<string, string>,
+    devDependencies: (pkg.devDependencies ?? {}) as Record<string, string>,
+    overrides: (pkg.overrides ?? {}) as Record<string, string>,
+    pnpmOverrides: (pnpm.overrides ?? {}) as Record<string, string>,
+    resolutions: (pkg.resolutions ?? {}) as Record<string, string>,
+  };
+}
+
+function depsEqual(a: DepSnapshot, b: DepSnapshot): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Compares package.json dep sections on each branch against origin/main.
+ * Runs comparisons in parallel. Branches that can't be read are treated as synced.
+ */
+export async function getBranchSyncStatuses(
+  projectPath: string,
+  branches: string[]
+): Promise<BranchSyncStatus[]> {
+  const { stdout: mainPkgRaw } = await execFileAsync(
+    'git',
+    ['show', 'origin/main:package.json'],
+    { cwd: projectPath, timeout: 10000 }
+  );
+  const mainDeps = extractDeps(JSON.parse(mainPkgRaw) as Record<string, unknown>);
+
+  return Promise.all(
+    branches.map(async (branch): Promise<BranchSyncStatus> => {
+      try {
+        const { stdout: branchPkgRaw } = await execFileAsync(
+          'git',
+          ['show', `origin/${branch}:package.json`],
+          { cwd: projectPath, timeout: 10000 }
+        );
+        const branchDeps = extractDeps(JSON.parse(branchPkgRaw) as Record<string, unknown>);
+        return {
+          branch,
+          status: depsEqual(mainDeps, branchDeps) ? 'synced' : 'out_of_sync',
+        };
+      } catch {
+        return { branch, status: 'synced' };
+      }
+    })
+  );
+}
+
+/**
+ * Syncs package.json from origin/main onto `branch`, regenerates the lockfile,
+ * then either opens a GitHub PR or pushes directly per `config`.
+ *
+ * Uses a git worktree so the project's working tree is not disturbed.
+ * Always removes the worktree in a finally block.
+ */
+export async function propagateBranch(
+  projectPath: string,
+  branch: string,
+  config: PropagationConfig,
+  owner: string,
+  repo: string,
+  token: string | null
+): Promise<BranchSyncStatus> {
+  const safeBranch = branch.replace(/[^a-zA-Z0-9-_]/g, '-');
+  const worktreePath = `/tmp/hexops-prop-${safeBranch}-${Date.now()}`;
+
+  try {
+    // Create worktree on target branch
+    await execFileAsync(
+      'git',
+      ['worktree', 'add', worktreePath, `origin/${branch}`],
+      { cwd: projectPath, timeout: 15000 }
+    );
+
+    // Apply package.json from main
+    try {
+      await execFileAsync(
+        'git',
+        ['checkout', 'origin/main', '--', 'package.json'],
+        { cwd: worktreePath, timeout: 10000 }
+      );
+    } catch (err) {
+      return {
+        branch,
+        status: 'conflict',
+        error: `Failed to apply package.json from main: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    // Check if anything actually changed
+    const { stdout: diffOut } = await execFileAsync(
+      'git',
+      ['diff', '--name-only'],
+      { cwd: worktreePath }
+    );
+    if (!diffOut.trim()) {
+      return { branch, status: 'synced' };
+    }
+
+    // Regenerate lockfile
+    const pm = detectPackageManager(worktreePath);
+    const [cmd, ...args] = INSTALL_CMD[pm];
+    try {
+      await execFileAsync(cmd, args, { cwd: worktreePath, timeout: 120000 });
+    } catch (err) {
+      // Revert package.json on lockfile failure
+      await execFileAsync('git', ['checkout', '--', 'package.json'], { cwd: worktreePath }).catch(() => {});
+      return {
+        branch,
+        status: 'conflict',
+        error: `Lockfile regen failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    const lockFile = LOCK_FILES[pm];
+
+    if (config.openPR) {
+      if (!token) {
+        return { branch, status: 'conflict', error: 'GitHub token required for PR mode' };
+      }
+      const syncBranch = `hexops/sync-${safeBranch}-${Date.now()}`;
+      await execFileAsync('git', ['checkout', '-b', syncBranch], { cwd: worktreePath, timeout: 5000 });
+      await execFileAsync('git', ['add', 'package.json', lockFile], { cwd: worktreePath });
+      await execFileAsync(
+        'git',
+        ['commit', '-m', `chore: sync package.json from main → ${branch}`],
+        { cwd: worktreePath, timeout: 10000 }
+      );
+      await execFileAsync('git', ['push', 'origin', syncBranch], { cwd: worktreePath, timeout: 30000 });
+      try {
+        const prUrl = await openPropagationPR(owner, repo, syncBranch, branch, token);
+        return { branch, status: 'propagated', prUrl };
+      } catch (err) {
+        return {
+          branch,
+          status: 'conflict',
+          error: `Branch pushed but PR creation failed: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+    } else {
+      await execFileAsync('git', ['add', 'package.json', lockFile], { cwd: worktreePath });
+      await execFileAsync(
+        'git',
+        ['commit', '-m', `chore: sync package.json from main → ${branch}`],
+        { cwd: worktreePath, timeout: 10000 }
+      );
+      await execFileAsync(
+        'git',
+        ['push', 'origin', `HEAD:${branch}`],
+        { cwd: worktreePath, timeout: 30000 }
+      );
+      return { branch, status: 'propagated' };
+    }
+  } finally {
+    await execFileAsync(
+      'git',
+      ['worktree', 'remove', '--force', worktreePath],
+      { cwd: projectPath, timeout: 10000 }
+    ).catch(() => {});
+  }
+}

--- a/src/lib/branch-propagator.ts
+++ b/src/lib/branch-propagator.ts
@@ -168,7 +168,7 @@ export async function propagateBranch(
     // Check if anything actually changed
     const { stdout: diffOut } = await execFileAsync(
       'git',
-      ['diff', '--name-only'],
+      ['diff', '--cached', '--name-only'],
       { cwd: worktreePath }
     );
     if (!diffOut.trim()) {

--- a/src/lib/dependabot-detector.ts
+++ b/src/lib/dependabot-detector.ts
@@ -1,0 +1,65 @@
+import { exec } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+const execAsync = promisify(exec);
+
+export interface DetectorResult {
+  managed: boolean;
+  owner: string | null;
+  repo: string | null;
+}
+
+/**
+ * Returns true if .github/dependabot.yml exists in the project root.
+ */
+export function hasDependabotConfig(projectPath: string): boolean {
+  return existsSync(path.join(projectPath, '.github', 'dependabot.yml'));
+}
+
+/**
+ * Parses GitHub owner and repo from the git remote URL.
+ * Handles both SSH (git@github.com:owner/repo.git) and HTTPS formats.
+ * Returns null for both if the remote is not a GitHub URL.
+ */
+export async function parseGitHubRemote(
+  projectPath: string
+): Promise<{ owner: string | null; repo: string | null }> {
+  try {
+    const { stdout } = await execAsync('git remote get-url origin', {
+      cwd: projectPath,
+      timeout: 5000,
+    });
+    const url = stdout.trim();
+
+    // SSH format: git@github.com:owner/repo.git
+    const sshMatch = url.match(/git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/);
+    if (sshMatch) {
+      return { owner: sshMatch[1], repo: sshMatch[2] };
+    }
+
+    // HTTPS format: https://github.com/owner/repo.git
+    const httpsMatch = url.match(/github\.com\/([^/]+)\/(.+?)(?:\.git)?$/);
+    if (httpsMatch) {
+      return { owner: httpsMatch[1], repo: httpsMatch[2] };
+    }
+
+    return { owner: null, repo: null };
+  } catch {
+    return { owner: null, repo: null };
+  }
+}
+
+/**
+ * Full detection: checks for dependabot.yml and parses the git remote.
+ * Returns managed=false immediately if dependabot.yml is absent.
+ */
+export async function detectDependabot(projectPath: string): Promise<DetectorResult> {
+  if (!hasDependabotConfig(projectPath)) {
+    return { managed: false, owner: null, repo: null };
+  }
+
+  const { owner, repo } = await parseGitHubRemote(projectPath);
+  return { managed: true, owner, repo };
+}

--- a/src/lib/escalation-store.ts
+++ b/src/lib/escalation-store.ts
@@ -1,0 +1,69 @@
+import fs from 'fs'
+import path from 'path'
+import type { EscalateRecord, EscalationStore } from './types'
+
+const ESCALATIONS_PATH = path.join(process.cwd(), '.hexops', 'patches', 'escalations.json')
+
+function readStore(): EscalationStore {
+  if (!fs.existsSync(ESCALATIONS_PATH)) {
+    return { records: [] }
+  }
+  try {
+    return JSON.parse(fs.readFileSync(ESCALATIONS_PATH, 'utf-8')) as EscalationStore
+  } catch {
+    return { records: [] }
+  }
+}
+
+function writeStore(store: EscalationStore): void {
+  fs.mkdirSync(path.dirname(ESCALATIONS_PATH), { recursive: true })
+  fs.writeFileSync(ESCALATIONS_PATH, JSON.stringify(store, null, 2))
+}
+
+export function getAllEscalations(): EscalateRecord[] {
+  return readStore().records
+}
+
+export function getEscalationsForProject(projectId: string): EscalateRecord[] {
+  return readStore().records.filter(r => r.projectId === projectId)
+}
+
+export function addEscalation(record: EscalateRecord): void {
+  const store = readStore()
+  // Remove any existing record for same project+package (one active record per package per project)
+  store.records = store.records.filter(
+    r => !(r.projectId === record.projectId && r.package === record.package && !r.resolvedAt)
+  )
+  store.records.push(record)
+  writeStore(store)
+}
+
+export function removeEscalation(id: string): boolean {
+  const store = readStore()
+  const before = store.records.length
+  store.records = store.records.filter(r => r.id !== id)
+  if (store.records.length === before) return false
+  writeStore(store)
+  return true
+}
+
+export function resolveEscalation(id: string): void {
+  const store = readStore()
+  const record = store.records.find(r => r.id === id)
+  if (record) {
+    record.resolvedAt = new Date().toISOString()
+    writeStore(store)
+  }
+}
+
+export function getEscalationConfig(projectConfig: { escalation?: { acceptedRiskMaxDays?: number; autoCommit?: boolean; autoPush?: boolean } }): {
+  acceptedRiskMaxDays: number
+  autoCommit: boolean
+  autoPush: boolean
+} {
+  return {
+    acceptedRiskMaxDays: projectConfig.escalation?.acceptedRiskMaxDays ?? 90,
+    autoCommit: projectConfig.escalation?.autoCommit ?? false,
+    autoPush: projectConfig.escalation?.autoPush ?? false,
+  }
+}

--- a/src/lib/escalation-store.ts
+++ b/src/lib/escalation-store.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import type { EscalateRecord, EscalationStore } from './types'
+import type { EscalateRecord, EscalationConfig, EscalationStore } from './types'
 
 const ESCALATIONS_PATH = path.join(process.cwd(), '.hexops', 'patches', 'escalations.json')
 
@@ -16,8 +16,12 @@ function readStore(): EscalationStore {
 }
 
 function writeStore(store: EscalationStore): void {
-  fs.mkdirSync(path.dirname(ESCALATIONS_PATH), { recursive: true })
-  fs.writeFileSync(ESCALATIONS_PATH, JSON.stringify(store, null, 2))
+  try {
+    fs.mkdirSync(path.dirname(ESCALATIONS_PATH), { recursive: true })
+    fs.writeFileSync(ESCALATIONS_PATH, JSON.stringify(store, null, 2))
+  } catch {
+    // Ignore write errors — store remains at last good state
+  }
 }
 
 export function getAllEscalations(): EscalateRecord[] {
@@ -56,11 +60,9 @@ export function resolveEscalation(id: string): void {
   }
 }
 
-export function getEscalationConfig(projectConfig: { escalation?: { acceptedRiskMaxDays?: number; autoCommit?: boolean; autoPush?: boolean } }): {
-  acceptedRiskMaxDays: number
-  autoCommit: boolean
-  autoPush: boolean
-} {
+export function getEscalationConfig(
+  projectConfig: { escalation?: Partial<EscalationConfig> }
+): EscalationConfig {
   return {
     acceptedRiskMaxDays: projectConfig.escalation?.acceptedRiskMaxDays ?? 90,
     autoCommit: projectConfig.escalation?.autoCommit ?? false,

--- a/src/lib/github-client.ts
+++ b/src/lib/github-client.ts
@@ -1,0 +1,76 @@
+import type { DependabotPR } from './types';
+
+const GITHUB_API = 'https://api.github.com';
+
+/**
+ * Fetches open PRs authored by dependabot[bot] for a given repo.
+ * Returns an empty array (not an error) if token is missing.
+ * Throws on non-401/403/404 HTTP errors.
+ */
+export async function fetchDependabotPRs(
+  owner: string,
+  repo: string,
+  token: string | null
+): Promise<DependabotPR[]> {
+  if (!token) return [];
+
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    Authorization: `Bearer ${token}`,
+  };
+
+  const url = `${GITHUB_API}/repos/${owner}/${repo}/pulls?state=open&per_page=100`;
+  const response = await fetch(url, { headers });
+
+  if (response.status === 401 || response.status === 403) {
+    throw new Error(`GitHub API auth failed (${response.status}) — check token`);
+  }
+  if (response.status === 404) {
+    throw new Error(`Repo ${owner}/${repo} not found or token lacks access`);
+  }
+  if (!response.ok) {
+    throw new Error(`GitHub API error: ${response.status}`);
+  }
+
+  const prs = (await response.json()) as GitHubPR[];
+
+  return prs
+    .filter((pr) => pr.user.login === 'dependabot[bot]')
+    .map(mapPR);
+}
+
+interface GitHubPR {
+  number: number;
+  title: string;
+  html_url: string;
+  state: string;
+  mergeable: boolean | null;
+  draft: boolean;
+  created_at: string;
+  updated_at: string;
+  labels: Array<{ name: string }>;
+  user: { login: string };
+}
+
+function mapPR(pr: GitHubPR): DependabotPR {
+  const labels = pr.labels.map((l) => l.name);
+  const updateType =
+    labels.find((l) => l.startsWith('version-update:')) ?? '';
+  const dependencyGroup =
+    labels.find((l) => l.startsWith('group:'))?.replace('group:', '') ?? null;
+
+  return {
+    number: pr.number,
+    title: pr.title,
+    url: pr.html_url,
+    state: pr.state as DependabotPR['state'],
+    mergeable: pr.mergeable,
+    draft: pr.draft,
+    createdAt: pr.created_at,
+    updatedAt: pr.updated_at,
+    labels,
+    updateType,
+    dependencyGroup,
+  };
+}

--- a/src/lib/github-client.ts
+++ b/src/lib/github-client.ts
@@ -74,3 +74,45 @@ function mapPR(pr: GitHubPR): DependabotPR {
     dependencyGroup,
   };
 }
+
+/**
+ * Opens a PR on GitHub from `head` branch targeting `base` branch.
+ * Returns the PR's html_url.
+ * Throws if token is missing or API call fails.
+ */
+export async function openPropagationPR(
+  owner: string,
+  repo: string,
+  head: string,
+  base: string,
+  token: string | null
+): Promise<string> {
+  if (!token) throw new Error('GitHub token required to open PRs');
+
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
+
+  const url = `${GITHUB_API}/repos/${owner}/${repo}/pulls`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      title: `chore: sync package.json deps from main → ${base}`,
+      head,
+      base,
+      body: 'Automated branch propagation by HexOps. Syncs `package.json` deps from `main` and regenerates the lockfile.\n\nReview the diff and merge when ready.',
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`GitHub PR creation failed (${response.status}): ${text}`);
+  }
+
+  const pr = (await response.json()) as { html_url: string };
+  return pr.html_url;
+}

--- a/src/lib/lockfile-checker.ts
+++ b/src/lib/lockfile-checker.ts
@@ -25,12 +25,27 @@ export function checkLockFileFreshness(projectPath: string): LockfileCheckResult
   const pkgJsonPath = join(projectPath, 'package.json');
   if (!existsSync(pkgJsonPath)) return { fresh: true, mismatches: [], lockfileType: pm };
 
-  let pkgJson: { dependencies?: Record<string, string>; devDependencies?: Record<string, string> };
+  let pkgJson: {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+    overrides?: Record<string, string>;
+    pnpm?: { overrides?: Record<string, string> };
+    resolutions?: Record<string, string>;
+  };
   try {
     pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
   } catch {
     return { fresh: true, mismatches: [], lockfileType: pm };
   }
+
+  // Collect packages that have a package manager override/resolution.
+  // When an override exists, pnpm/npm records the OVERRIDE spec in the lockfile
+  // (not the direct dep spec), so a mismatch is expected and not a stale lockfile.
+  const overriddenPackages = new Set<string>([
+    ...Object.keys(pkgJson.pnpm?.overrides || {}),
+    ...Object.keys(pkgJson.overrides || {}),
+    ...Object.keys(pkgJson.resolutions || {}),
+  ]);
 
   const allDeps: Record<string, { spec: string; section: 'dependencies' | 'devDependencies' }> = {};
   for (const [name, spec] of Object.entries(pkgJson.dependencies || {})) {
@@ -57,6 +72,10 @@ export function checkLockFileFreshness(projectPath: string): LockfileCheckResult
   const mismatches: LockfileMismatch[] = [];
 
   for (const [name, { spec, section }] of Object.entries(allDeps)) {
+    // Skip packages that have an override — pnpm/npm writes the override spec
+    // into the lockfile, not the direct dep spec, so differences are expected.
+    if (overriddenPackages.has(name)) continue;
+
     const lockSpec = lockfileSpecs[name];
     if (lockSpec && lockSpec !== spec) {
       mismatches.push({

--- a/src/lib/patch-scanner.ts
+++ b/src/lib/patch-scanner.ts
@@ -23,6 +23,7 @@ import {
 import { scanSpecVulnerabilities } from './spec-scanner';
 import { checkLockFileFreshness } from './lockfile-checker';
 import { hasDependabotConfig } from './dependabot-detector';
+import { getAllEscalations, resolveEscalation } from './escalation-store';
 
 const execAsync = promisify(exec);
 
@@ -543,6 +544,56 @@ export async function scanProject(
 }
 
 /**
+ * Annotate queue items with escalation state from the escalation store.
+ * Auto-resolves escalations when upstream provides a fix (except accepted_risk).
+ * Filters out active accepted_risk items (but keeps expired ones).
+ */
+function annotateWithEscalations(items: PatchQueueItem[]): PatchQueueItem[] {
+  const escalations = getAllEscalations()
+  const now = new Date()
+
+  return items.map(item => {
+    // Find active escalation for this project+package (no resolvedAt)
+    const record = escalations.find(
+      r => r.projectId === item.projectId && r.package === item.package && !r.resolvedAt
+    )
+    if (!record) return item
+
+    // If upstream now provides a fix and this is an override/major escalation,
+    // auto-resolve the escalation so it re-surfaces as a normal patchable item
+    if (item.fixAvailable && record.action !== 'accepted_risk') {
+      resolveEscalation(record.id)
+      return item // re-surface as normal patchable item
+    }
+
+    const base = {
+      ...item,
+      escalationId: record.id,
+      escalationReason: record.reason,
+    }
+
+    if (record.action === 'accepted_risk') {
+      const expired = record.expiresAt ? new Date(record.expiresAt) < now : false
+      return {
+        ...base,
+        escalationStatus: expired ? 'accepted_risk_expired' as const : 'accepted_risk' as const,
+        escalationExpiresAt: record.expiresAt,
+      }
+    }
+
+    if (record.action === 'force_override') {
+      return { ...base, escalationStatus: 'force_override_pending' as const }
+    }
+
+    if (record.action === 'force_major') {
+      return { ...base, escalationStatus: 'force_major_pending' as const }
+    }
+
+    return item
+  })
+}
+
+/**
  * Build priority queue from multiple project caches
  * Creates one entry per project per package (1:1 relationship)
  */
@@ -693,8 +744,9 @@ export function buildPriorityQueue(
 
   // Sort by priority (lower number = higher priority)
   queue.sort((a, b) => a.priority - b.priority);
-
-  return { queue, summary };
+  const annotated = annotateWithEscalations(queue)
+  const filtered = annotated.filter(item => item.escalationStatus !== 'accepted_risk')
+  return { queue: filtered, summary };
 }
 
 /**

--- a/src/lib/patch-scanner.ts
+++ b/src/lib/patch-scanner.ts
@@ -22,6 +22,7 @@ import {
 } from './patch-storage';
 import { scanSpecVulnerabilities } from './spec-scanner';
 import { checkLockFileFreshness } from './lockfile-checker';
+import { hasDependabotConfig } from './dependabot-detector';
 
 const execAsync = promisify(exec);
 
@@ -467,6 +468,9 @@ export async function scanProject(
     if (cached) return cached;
   }
 
+  // Detect dependabot management early (used to annotate scan results)
+  const isManaged = hasDependabotConfig(project.path);
+
   // Run scans in parallel (spec scanner works without lock files)
   const [outdated, auditVulns, specVulns] = await Promise.all([
     scanOutdated(project),
@@ -497,8 +501,12 @@ export async function scanProject(
     }
   }
 
+  // Annotate results with dependabot management status
+  const annotatedOutdated = outdated.map((pkg) => ({ ...pkg, dependabotManaged: isManaged }));
+  const annotatedVulnerabilities = vulnerabilities.map((v) => ({ ...v, dependabotManaged: isManaged }));
+
   // Create and save cache
-  const cache = createProjectCache(project.id, outdated, vulnerabilities);
+  const cache = createProjectCache(project.id, annotatedOutdated, annotatedVulnerabilities);
   writeProjectCache(cache);
 
   // Update aggregate state

--- a/src/lib/patch-scanner.ts
+++ b/src/lib/patch-scanner.ts
@@ -562,7 +562,11 @@ function annotateWithEscalations(items: PatchQueueItem[]): PatchQueueItem[] {
     // If upstream now provides a fix and this is an override/major escalation,
     // auto-resolve the escalation so it re-surfaces as a normal patchable item
     if (item.fixAvailable && record.action !== 'accepted_risk') {
-      resolveEscalation(record.id)
+      try {
+        resolveEscalation(record.id)
+      } catch {
+        // Non-fatal — re-surface item even if resolve write fails
+      }
       return item // re-surface as normal patchable item
     }
 

--- a/src/lib/patch-scanner.ts
+++ b/src/lib/patch-scanner.ts
@@ -381,15 +381,19 @@ export async function scanVulnerabilities(
           }
         }
 
-        // Transitive deps: determine fix strategy
-        if (!vuln.isDirect && parentPackage) {
+        // Transitive deps: determine fix strategy.
+        // Also covers self-advisory packages (e.g. hono) where via[] contains only advisory
+        // objects (no string parent references), so parentPackage is undefined but the vuln
+        // IS in this package itself and needs a direct override.
+        if (!vuln.isDirect && (parentPackage || !fixVersion)) {
           if (fixByParent && !isBreakingFix) {
             // Best path: update the parent dependency (non-breaking)
             fixAvailable = true;
             fixVersion = fixByParent.version;
           } else {
-            // Fallback: apply a package manager override for this package directly
-            // Extract fix version from advisory range in via objects
+            // Fallback: apply a package manager override for this package directly.
+            // Extract fix version from advisory range in via objects (works for both
+            // "via parent" cases and self-advisory packages like hono).
             let overrideVersion: string | undefined;
             const viaAdvisories = vuln.via?.filter(v => typeof v === 'object' && v.range) as
               Array<{ range: string }> | undefined;

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -18,6 +18,9 @@ const DEFAULT_GLOBAL_SETTINGS: GlobalSettings = {
       commitPrefix: '',
       pushAfterCommit: false,
     },
+    github: {
+      token: null,
+    },
   },
   patching: {
     defaultLockfileResolution: 'clean-slate',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,30 @@
+// Escalation Types
+
+export type EscalateAction = 'force_override' | 'force_major' | 'accepted_risk';
+
+export interface EscalationConfig {
+  acceptedRiskMaxDays: number;   // default 90
+  autoCommit: boolean;           // force_override: commit after patching
+  autoPush: boolean;             // force_override: push after committing
+}
+
+export interface EscalateRecord {
+  id: string;                    // uuid (crypto.randomUUID())
+  projectId: string;
+  package: string;
+  action: EscalateAction;
+  reason: string;
+  createdAt: string;             // ISO 8601
+  expiresAt?: string;            // accepted_risk only
+  resolvedAt?: string;           // set by scanner when upstream patch becomes available
+  overrideVersion?: string;      // force_override: version pinned to
+  targetVersion?: string;        // force_major: target version
+}
+
+export interface EscalationStore {
+  records: EscalateRecord[];
+}
+
 export interface ProjectConfig {
   id: string;
   name: string;
@@ -154,33 +181,6 @@ export interface DependabotConfig {
   prs: DependabotPR[];
   fetchedAt: string | null;
   error: string | null;
-}
-
-// Escalation Types
-
-export type EscalateAction = 'force_override' | 'force_major' | 'accepted_risk'
-
-export interface EscalationConfig {
-  acceptedRiskMaxDays: number   // default 90
-  autoCommit: boolean           // force_override: commit after patching
-  autoPush: boolean             // force_override: push after committing
-}
-
-export interface EscalateRecord {
-  id: string                    // uuid (crypto.randomUUID())
-  projectId: string
-  package: string
-  action: EscalateAction
-  reason: string
-  createdAt: string             // ISO 8601
-  expiresAt?: string            // accepted_risk only
-  resolvedAt?: string           // set by scanner when upstream patch becomes available
-  overrideVersion?: string      // force_override: version pinned to
-  targetVersion?: string        // force_major: target version
-}
-
-export interface EscalationStore {
-  records: EscalateRecord[]
 }
 
 // Patch Management Types

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -44,6 +44,7 @@ export interface ProjectConfig {
     owner: string;
     repo: string;
   };
+  propagation?: Partial<PropagationConfig>;
 }
 
 export interface ProjectExtendedStatus {
@@ -181,6 +182,19 @@ export interface DependabotConfig {
   prs: DependabotPR[];
   fetchedAt: string | null;
   error: string | null;
+}
+
+export interface BranchSyncStatus {
+  branch: string;
+  status: 'synced' | 'out_of_sync' | 'conflict' | 'propagated';
+  prUrl?: string;
+  error?: string;
+}
+
+export interface PropagationConfig {
+  activeBranchDays: number;
+  openPR: boolean;
+  autoPush: boolean;
 }
 
 // Patch Management Types

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,6 +12,10 @@ export interface ProjectConfig {
   };
   holds?: string[];  // Package names on hold (excluded from updates)
   settings?: Partial<ProjectSettings>;  // Per-project settings overrides
+  github?: {
+    owner: string;
+    repo: string;
+  };
 }
 
 export interface ProjectExtendedStatus {
@@ -54,6 +58,9 @@ export interface GlobalSettings {
       defaultBranch: string;
       commitPrefix: string;
       pushAfterCommit: boolean;
+    };
+    github: {
+      token: string | null;
     };
   };
   patching: {
@@ -121,6 +128,31 @@ export interface LockfileResolutionResult {
   detectedVia: 'lockfile' | 'packageJson' | 'workspaceConfig' | 'npmrc' | 'fallback';
   actions: string[];
   error?: string;
+}
+
+// Dependabot Types
+
+export interface DependabotPR {
+  number: number;
+  title: string;
+  url: string;
+  state: 'open' | 'closed' | 'merged';
+  mergeable: boolean | null;
+  draft: boolean;
+  createdAt: string;
+  updatedAt: string;
+  labels: string[];
+  updateType: 'version-update:semver-patch' | 'version-update:semver-minor' | 'version-update:semver-major' | string;
+  dependencyGroup: string | null;
+}
+
+export interface DependabotConfig {
+  managed: boolean;
+  owner: string | null;
+  repo: string | null;
+  prs: DependabotPR[];
+  fetchedAt: string | null;
+  error: string | null;
 }
 
 // Patch Management Types
@@ -206,6 +238,7 @@ export interface OutdatedPackage {
   wanted: string;
   latest: string;
   type: 'dependencies' | 'devDependencies';
+  dependabotManaged?: boolean;
 }
 
 export interface VulnerabilityInfo {
@@ -228,6 +261,7 @@ export interface VulnerabilityInfo {
   cves?: string[];              // CVE identifiers (e.g., ["CVE-2024-12345"])
   url?: string;                 // Link to advisory (GitHub/npm)
   advisoryId?: number;          // npm advisory ID
+  dependabotManaged?: boolean;
 }
 
 export interface ProjectPatchCache {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -215,10 +215,10 @@ export interface PatchQueueItem {
   url?: string;
   advisoryId?: number;
   // Escalation state (set by scanner when an EscalateRecord exists for this package)
-  escalationId?: string
-  escalationStatus?: 'accepted_risk' | 'accepted_risk_expired' | 'force_override_pending' | 'force_major_pending'
-  escalationReason?: string
-  escalationExpiresAt?: string
+  escalationId?: string;
+  escalationStatus?: 'accepted_risk' | 'accepted_risk_expired' | 'force_override_pending' | 'force_major_pending';
+  escalationReason?: string;
+  escalationExpiresAt?: string;
 }
 
 export interface PatchSummary {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,6 +11,7 @@ export interface ProjectConfig {
     [key: string]: string;
   };
   holds?: string[];  // Package names on hold (excluded from updates)
+  escalation?: Partial<EscalationConfig>;
   settings?: Partial<ProjectSettings>;  // Per-project settings overrides
   github?: {
     owner: string;
@@ -155,6 +156,33 @@ export interface DependabotConfig {
   error: string | null;
 }
 
+// Escalation Types
+
+export type EscalateAction = 'force_override' | 'force_major' | 'accepted_risk'
+
+export interface EscalationConfig {
+  acceptedRiskMaxDays: number   // default 90
+  autoCommit: boolean           // force_override: commit after patching
+  autoPush: boolean             // force_override: push after committing
+}
+
+export interface EscalateRecord {
+  id: string                    // uuid (crypto.randomUUID())
+  projectId: string
+  package: string
+  action: EscalateAction
+  reason: string
+  createdAt: string             // ISO 8601
+  expiresAt?: string            // accepted_risk only
+  resolvedAt?: string           // set by scanner when upstream patch becomes available
+  overrideVersion?: string      // force_override: version pinned to
+  targetVersion?: string        // force_major: target version
+}
+
+export interface EscalationStore {
+  records: EscalateRecord[]
+}
+
 // Patch Management Types
 
 export type UpdateType = 'patch' | 'minor' | 'major';
@@ -186,6 +214,11 @@ export interface PatchQueueItem {
   cves?: string[];
   url?: string;
   advisoryId?: number;
+  // Escalation state (set by scanner when an EscalateRecord exists for this package)
+  escalationId?: string
+  escalationStatus?: 'accepted_risk' | 'accepted_risk_expired' | 'force_override_pending' | 'force_major_pending'
+  escalationReason?: string
+  escalationExpiresAt?: string
 }
 
 export interface PatchSummary {

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,10 +1,11 @@
-/**
- * Application version - update this when releasing new versions
- * Also update: package.json, docs/dev-notes.md
- */
-export const APP_VERSION = '0.9.0';
+import pkg from '../../package.json';
 
 /**
- * Build metadata (can be set by CI/CD)
+ * Application version — sourced from package.json to stay in sync automatically.
  */
-export const BUILD_DATE = '2026-01-29';
+export const APP_VERSION: string = pkg.version;
+
+/**
+ * Build date — set at startup.
+ */
+export const BUILD_DATE: string = new Date().toISOString().split('T')[0];


### PR DESCRIPTION
## Summary

- Detects Dependabot-managed projects via `.github/dependabot.yml` presence and git remote parsing
- Adds Dependabot panel to project detail view showing open PRs (merge status, dependency group, update type)
- Patches page switches to monitor-only mode for managed projects instead of showing the patch runner
- Scanner annotates outdated packages and vulnerabilities with `dependabotManaged: true` for context
- GitHub token configurable via `settings.integrations.github.token`
- Bumps version to 0.12.0; fixes version display to auto-sync from `package.json`

## Closes

- Closes #65 (Dependabot integration)
- Closes #66 (version display not updating)

## Test plan

- [ ] Open a project with `.github/dependabot.yml` — badge appears on card, Dependabot panel visible in detail
- [ ] Open a project without `.github/dependabot.yml` — no badge, patch runner shows normally
- [ ] Set `integrations.github.token` in settings — PR list populates with merge status
- [ ] Without token — panel shows managed badge + "add token" prompt, no crash
- [ ] Patches page: managed project shows monitor view, unmanaged shows patch runner
- [ ] Version displayed in app header matches `package.json` version (0.12.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)