### PR TITLE
ci: add GitHub Actions pipeline + refresh README badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ci:
+    name: lint · typecheck · test · build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Lint (non-blocking)
+        run: pnpm lint
+        continue-on-error: true
+
+      - name: Build
+        run: |
+          cp -n hexops.config.example.json hexops.config.json || true
+          pnpm build

--- a/README.md
+++ b/README.md
@@ -4,10 +4,13 @@
 
 Manage 5, 15, or 50+ local dev projects from a single web interface. Start/stop servers, batch-patch vulnerabilities, monitor system health, and deploy to Vercel without touching a terminal.
 
+[![CI](https://github.com/Hexaxia-Technologies/hexops/actions/workflows/ci.yml/badge.svg)](https://github.com/Hexaxia-Technologies/hexops/actions/workflows/ci.yml)
+![Version](https://img.shields.io/github/package-json/v/Hexaxia-Technologies/hexops)
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
-![Version](https://img.shields.io/badge/version-0.20.0-green.svg)
-![Node](https://img.shields.io/badge/node-20%2B-brightgreen.svg)
+![Node](https://img.shields.io/badge/node-24-brightgreen.svg)
 ![Next.js](https://img.shields.io/badge/Next.js-16-black.svg)
+![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)
+![code style: biome](https://img.shields.io/badge/code_style-biome-60a5fa.svg)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "biome lint src",
+    "typecheck": "tsc --noEmit",
     "mcp": "tsx src/mcp/server.ts",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@hexaxia-labs/supply-sentinel": "file:../supply-sentinel",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-scroll-area": "^1.2.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  postcss: 8.5.15
+  postcss: 8.5.14
   ip-address: 10.2.0
   vite: 8.0.13
   esbuild: 0.28.0
@@ -14,9 +14,6 @@ importers:
 
   .:
     dependencies:
-      '@hexaxia-labs/supply-sentinel':
-        specifier: file:../supply-sentinel
-        version: file:../supply-sentinel
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
@@ -372,11 +369,6 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
-
-  '@hexaxia-labs/supply-sentinel@file:../supply-sentinel':
-    resolution: {directory: ../supply-sentinel, type: directory}
-    engines: {node: '>=20'}
-    hasBin: true
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -1721,10 +1713,6 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
-  commander@12.1.0:
-    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
-    engines: {node: '>=18'}
-
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
     engines: {node: '>=18'}
@@ -2282,8 +2270,8 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.3:
@@ -2915,12 +2903,6 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
 
   '@floating-ui/utils@0.2.11': {}
-
-  '@hexaxia-labs/supply-sentinel@file:../supply-sentinel':
-    dependencies:
-      commander: 12.1.0
-      semver: 7.8.0
-      yaml: 2.9.0
 
   '@hono/node-server@1.19.14(hono@4.12.18)':
     dependencies:
@@ -3992,7 +3974,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.15
+      postcss: 8.5.14
       tailwindcss: 4.3.0
 
   '@tybys/wasm-util@0.10.2':
@@ -4196,8 +4178,6 @@ snapshots:
   client-only@0.0.1: {}
 
   clsx@2.1.1: {}
-
-  commander@12.1.0: {}
 
   content-disposition@1.1.0: {}
 
@@ -4625,7 +4605,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.29
       caniuse-lite: 1.0.30001792
-      postcss: 8.5.15
+      postcss: 8.5.14
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(react@19.2.6)
@@ -4681,7 +4661,7 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
-  postcss@8.5.15:
+  postcss@8.5.14:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -5168,7 +5148,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.14
       rolldown: 1.0.1
       tinyglobby: 0.2.16
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  postcss: 8.5.14
+  postcss: 8.5.15
   ip-address: 10.2.0
   vite: 8.0.13
   esbuild: 0.28.0
@@ -2270,8 +2270,8 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
-  postcss@8.5.14:
-    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.3:
@@ -3974,7 +3974,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.14
+      postcss: 8.5.15
       tailwindcss: 4.3.0
 
   '@tybys/wasm-util@0.10.2':
@@ -4605,7 +4605,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.29
       caniuse-lite: 1.0.30001792
-      postcss: 8.5.14
+      postcss: 8.5.15
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(react@19.2.6)
@@ -4661,7 +4661,7 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
-  postcss@8.5.14:
+  postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -5148,7 +5148,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.14
+      postcss: 8.5.15
       rolldown: 1.0.1
       tinyglobby: 0.2.16
     optionalDependencies:

--- a/src/components/detail-sections/supply-chain-section.tsx
+++ b/src/components/detail-sections/supply-chain-section.tsx
@@ -11,11 +11,7 @@ const TYPE_LABEL: Record<SupplyChainFindingType, string> = {
   'install-script': 'Install Script',
   'signature-invalid': 'Invalid Signature',
   'typosquat-suspect': 'Typosquat',
-  'dep-confusion': 'Dep Confusion',
-  'manifest-tamper': 'Manifest Tamper',
-  'maintainer-risk': 'Maintainer Risk',
-  'provenance': 'Provenance',
-  'blacklist': 'Blacklist',
+  'no-source': 'No Source',
 };
 
 const SEVERITY_DOT: Record<string, string> = {

--- a/src/lib/supply-chain-scanner.ts
+++ b/src/lib/supply-chain-scanner.ts
@@ -1,16 +1,8 @@
-// Thin adapter — delegates to @hexaxia-labs/supply-sentinel
-import { scanSupplyChain as _scan } from '@hexaxia-labs/supply-sentinel';
-import type { ScanResult, Finding } from '@hexaxia-labs/supply-sentinel';
+import { execSync } from 'child_process';
+import { existsSync, readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
 
-export type SupplyChainFindingType =
-  | 'install-script'
-  | 'signature-invalid'
-  | 'typosquat-suspect'
-  | 'dep-confusion'
-  | 'manifest-tamper'
-  | 'maintainer-risk'
-  | 'provenance'
-  | 'blacklist';
+export type SupplyChainFindingType = 'install-script' | 'signature-invalid' | 'typosquat-suspect' | 'no-source';
 
 export interface SupplyChainFinding {
   type: SupplyChainFindingType;
@@ -28,45 +20,222 @@ export interface SupplyChainResult {
   scannedPackages: number;
 }
 
-const DETECTOR_TO_TYPE: Record<string, SupplyChainFindingType> = {
-  'install-scripts': 'install-script',
-  'signature': 'signature-invalid',
-  'typosquat': 'typosquat-suspect',
-  'dep-confusion': 'dep-confusion',
-  'manifest-tamper': 'manifest-tamper',
-  'maintainer-risk': 'maintainer-risk',
-  'provenance': 'provenance',
-  'blacklist': 'blacklist',
-};
+// Packages that legitimately run install scripts (build native addons, binary downloads, etc.)
+const INSTALL_SCRIPT_WHITELIST = new Set([
+  'esbuild', 'esbuild-darwin-64', 'esbuild-darwin-arm64', 'esbuild-linux-64', 'esbuild-linux-arm64',
+  'esbuild-windows-64', 'sharp', 'canvas', 'bcrypt', 'node-gyp', 'fsevents',
+  'node-sass', 'sass', 'better-sqlite3', 'sqlite3', 'nodegit', 'grpc', '@grpc/grpc-js',
+  'husky', 'puppeteer', 'playwright', 'cypress', 'electron', '@electron/rebuild',
+  'prebuild-install', 'node-pre-gyp', 'node-addon-api', 'bindings',
+  'postinstall-postinstall', 'patch-patch', 'patch-package', 'prisma',
+  '@prisma/client', 'prisma-client-js', '@swc/core', 'lightningcss',
+  'turbo', '@next/swc-darwin-arm64', '@next/swc-linux-x64-gnu',
+  'optionator', 'keytar', 'dtrace-provider', 'cpu-features',
+]);
 
-function mapSeverity(s: string): 'high' | 'medium' | 'low' {
-  if (s === 'critical' || s === 'high') return 'high';
-  if (s === 'medium') return 'medium';
-  return 'low';
+// Commonly impersonated packages for typosquat detection
+const POPULAR_PACKAGES = [
+  'lodash', 'express', 'react', 'react-dom', 'axios', 'moment', 'chalk',
+  'typescript', 'webpack', 'babel-core', 'prettier', 'eslint', 'jest',
+  'mocha', 'vue', 'next', 'nuxt', 'gatsby', 'vite', 'rollup', 'parcel',
+  'commander', 'yargs', 'inquirer', 'dotenv', 'uuid', 'dayjs', 'date-fns',
+  'underscore', 'async', 'bluebird', 'request', 'node-fetch', 'got', 'superagent',
+  'morgan', 'cors', 'helmet', 'body-parser', 'multer', 'passport',
+  'mongoose', 'sequelize', 'typeorm', 'prisma', 'knex', 'redis', 'ioredis',
+  'socket.io', 'ws', 'rxjs', 'ramda', 'fp-ts', 'zod', 'joi', 'yup',
+  'classnames', 'styled-components', 'tailwindcss', 'antd', 'material-ui',
+  'lodash-es', 'immer', 'mobx', 'redux', 'zustand', 'jotai',
+];
+
+function levenshtein(a: string, b: string): number {
+  const m = a.length, n = b.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, (_, i) =>
+    Array.from({ length: n + 1 }, (_, j) => (i === 0 ? j : j === 0 ? i : 0))
+  );
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] = a[i - 1] === b[j - 1]
+        ? dp[i - 1][j - 1]
+        : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]);
+    }
+  }
+  return dp[m][n];
 }
 
-function mapFinding(f: Finding): SupplyChainFinding {
-  return {
-    type: DETECTOR_TO_TYPE[f.detector] ?? 'install-script',
-    severity: mapSeverity(f.severity),
-    package: f.package,
-    version: f.version,
-    detail: f.detail,
-  };
+function checkTyposquat(name: string): string | null {
+  // Strip scope for scoped packages
+  const bare = name.startsWith('@') ? name.split('/')[1] ?? name : name;
+  for (const popular of POPULAR_PACKAGES) {
+    if (bare === popular) return null; // exact match = not a typosquat
+    const dist = levenshtein(bare, popular);
+    // Flag if very close but not identical, and similar length (avoid false positives on short names)
+    if (dist === 1 && bare.length >= 4) return popular;
+    if (dist === 2 && bare.length >= 7) return popular;
+  }
+  return null;
 }
 
-export async function scanSupplyChain(
+function readDirectDeps(projectPath: string): Record<string, string> {
+  try {
+    const pkg = JSON.parse(readFileSync(join(projectPath, 'package.json'), 'utf-8'));
+    return { ...pkg.dependencies, ...pkg.devDependencies };
+  } catch {
+    return {};
+  }
+}
+
+function scanInstallScripts(
   projectPath: string,
-  projectId: string,
-): Promise<SupplyChainResult> {
-  const result: ScanResult = await _scan(projectPath, {
-    detectors: 'all',
-  });
+  directDeps: Record<string, string>
+): SupplyChainFinding[] {
+  const findings: SupplyChainFinding[] = [];
+  const nmPath = join(projectPath, 'node_modules');
+  if (!existsSync(nmPath)) return findings;
+
+  const INSTALL_HOOKS = ['preinstall', 'install', 'postinstall', 'prepare'];
+
+  const scanPkg = (pkgName: string) => {
+    const pkgJsonPath = join(nmPath, pkgName, 'package.json');
+    if (!existsSync(pkgJsonPath)) return;
+    try {
+      const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
+      const scripts: Record<string, string> = pkg.scripts ?? {};
+      const hooks = INSTALL_HOOKS.filter(h => scripts[h]);
+      if (hooks.length === 0) return;
+
+      const baseName = pkgName.startsWith('@') ? pkgName.split('/').slice(-1)[0] : pkgName;
+      if (INSTALL_SCRIPT_WHITELIST.has(pkgName) || INSTALL_SCRIPT_WHITELIST.has(baseName ?? '')) return;
+
+      const version = pkg.version ?? 'unknown';
+      const scriptDetails = hooks.map(h => `${h}: ${scripts[h]?.slice(0, 80)}`).join('; ');
+
+      findings.push({
+        type: 'install-script',
+        severity: pkgName in directDeps ? 'medium' : 'low',
+        package: pkgName,
+        version,
+        detail: `Install hook(s): ${scriptDetails}`,
+      });
+    } catch { /* skip */ }
+  };
+
+  try {
+    const entries = readdirSync(nmPath);
+    for (const entry of entries) {
+      if (entry.startsWith('.')) continue;
+      if (entry.startsWith('@')) {
+        // scoped packages
+        const scopePath = join(nmPath, entry);
+        try {
+          const scoped = readdirSync(scopePath);
+          for (const s of scoped) scanPkg(`${entry}/${s}`);
+        } catch { /* skip */ }
+      } else {
+        scanPkg(entry);
+      }
+    }
+  } catch { /* skip */ }
+
+  return findings;
+}
+
+function scanAuditSignatures(
+  projectPath: string,
+  packageManager: string
+): SupplyChainFinding[] {
+  if (packageManager !== 'npm') return [];
+  try {
+    const output = execSync('npm audit signatures 2>&1', {
+      cwd: projectPath,
+      timeout: 30000,
+      maxBuffer: 512 * 1024,
+    }).toString();
+
+    const findings: SupplyChainFinding[] = [];
+    // npm audit signatures outputs lines like:
+    // "  X packages have invalid signatures"
+    // "  package@version: invalid signature"
+    const invalidMatch = output.match(/(\d+) packages? (?:have|with) invalid/i);
+    if (invalidMatch) {
+      const pkgLines = output.split('\n').filter(l => l.includes(': '));
+      for (const line of pkgLines.slice(0, 10)) {
+        const m = line.match(/^\s+(.+@\S+):\s+(.+)/);
+        if (!m) continue;
+        const [, pkgVer, reason] = m;
+        const atIdx = pkgVer.lastIndexOf('@');
+        const pkg = pkgVer.slice(0, atIdx);
+        const ver = pkgVer.slice(atIdx + 1);
+        findings.push({
+          type: 'signature-invalid',
+          severity: 'high',
+          package: pkg,
+          version: ver,
+          detail: reason?.trim() ?? 'Invalid registry signature',
+        });
+      }
+      if (findings.length === 0 && invalidMatch[1] !== '0') {
+        findings.push({
+          type: 'signature-invalid',
+          severity: 'high',
+          package: '(multiple)',
+          version: '',
+          detail: `${invalidMatch[1]} packages have invalid registry signatures`,
+        });
+      }
+    }
+    return findings;
+  } catch {
+    return [];
+  }
+}
+
+function scanTyposquats(directDeps: Record<string, string>): SupplyChainFinding[] {
+  const findings: SupplyChainFinding[] = [];
+  for (const [name, version] of Object.entries(directDeps)) {
+    const suspect = checkTyposquat(name);
+    if (suspect) {
+      findings.push({
+        type: 'typosquat-suspect',
+        severity: 'high',
+        package: name,
+        version,
+        detail: `Looks like a typo of "${suspect}" (edit distance ≤ 2)`,
+      });
+    }
+  }
+  return findings;
+}
+
+function detectPackageManager(projectPath: string): string {
+  if (existsSync(join(projectPath, 'pnpm-lock.yaml'))) return 'pnpm';
+  if (existsSync(join(projectPath, 'yarn.lock'))) return 'yarn';
+  return 'npm';
+}
+
+export async function scanSupplyChain(projectPath: string, projectId: string): Promise<SupplyChainResult> {
+  const start = Date.now();
+  const directDeps = readDirectDeps(projectPath);
+  const packageManager = detectPackageManager(projectPath);
+
+  const [installFindings, signatureFindings, typosquatFindings] = await Promise.all([
+    Promise.resolve(scanInstallScripts(projectPath, directDeps)),
+    Promise.resolve(scanAuditSignatures(projectPath, packageManager)),
+    Promise.resolve(scanTyposquats(directDeps)),
+  ]);
+
+  const findings = [...typosquatFindings, ...signatureFindings, ...installFindings];
+
+  const nmPath = join(projectPath, 'node_modules');
+  let scannedPackages = 0;
+  try {
+    scannedPackages = readdirSync(nmPath).filter(e => !e.startsWith('.')).length;
+  } catch { /* skip */ }
+
   return {
     projectId,
-    timestamp: result.timestamp,
-    duration: result.duration,
-    scannedPackages: result.scannedPackages,
-    findings: result.findings.map(mapFinding),
+    timestamp: new Date().toISOString(),
+    duration: Date.now() - start,
+    findings,
+    scannedPackages,
   };
 }


### PR DESCRIPTION
## Summary
- **CI pipeline** — first GitHub Actions workflow (`.github/workflows/ci.yml`): single `ci` job on Node 24 / pnpm 10. `typecheck` + `test` + `build` are blocking gates; `lint` runs non-blocking (pre-existing Biome warnings, tracked in #103).
- **README badges** — replace the stale hardcoded block with a live CI-status badge and a dynamic version badge (reads `package.json`), bump Node → 24, add `PRs welcome` + `code style: biome`.
- **`typecheck` script** — add `tsc --noEmit`.
- **Decouple supply-sentinel** — revert d373834 so `@hexaxia-labs/supply-sentinel` (`file:../supply-sentinel`) no longer breaks clean CI installs; restores the standalone inline scanner. Re-integration tracked in #102.
- **Lockfile sync** — reconcile `pnpm-lock.yaml` postcss override (8.5.14 → 8.5.15) exposed by the revert.

## Test Plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 94/94 passing
- [x] `pnpm build` — succeeds
- [ ] CI green on first run

Related: #102 (supply-sentinel re-integration), #103 (lint → zero, then gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
