### PR TITLE
CVE Lite: Apply → Commit → Push parity + remediation audit trail (#107)

### DIFF
--- a/src/app/api/projects/[id]/git-commit/route.ts
+++ b/src/app/api/projects/[id]/git-commit/route.ts
@@ -12,6 +12,9 @@ export async function POST(
 ) {
   const { id } = await params;
 
+  let source: string | undefined;
+  let advisories: string[] | undefined;
+
   try {
     const project = getProject(id);
 
@@ -24,6 +27,10 @@ export async function POST(
 
     const body = await request.json();
     const message = body.message?.trim();
+    source = typeof body.source === 'string' ? body.source : undefined;
+    advisories = Array.isArray(body.advisories)
+      ? body.advisories.filter((a: unknown): a is string => typeof a === 'string')
+      : undefined;
 
     if (!message) {
       return NextResponse.json(
@@ -65,7 +72,11 @@ export async function POST(
     // Log success
     logger.info('git', 'commit_created', `Committed changes: ${message.split('\n')[0]}`, {
       projectId: id,
-      meta: { message: message.split('\n')[0] },
+      meta: {
+        message: message.split('\n')[0],
+        ...(source ? { source } : {}),
+        ...(advisories ? { advisories } : {}),
+      },
     });
 
     return NextResponse.json({
@@ -79,7 +90,11 @@ export async function POST(
     // Log failure
     logger.error('git', 'commit_failed', `Commit failed: ${errorMessage}`, {
       projectId: id,
-      meta: { error: errorMessage },
+      meta: {
+        error: errorMessage,
+        ...(source ? { source } : {}),
+        ...(advisories ? { advisories } : {}),
+      },
     });
 
     return NextResponse.json(

--- a/src/app/api/projects/[id]/git-push/route.ts
+++ b/src/app/api/projects/[id]/git-push/route.ts
@@ -7,10 +7,15 @@ import { logger } from '@/lib/logger';
 const execFileAsync = promisify(execFile);
 
 export async function POST(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
+  const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+  const source = typeof body.source === 'string' ? body.source : undefined;
+  const advisories = Array.isArray(body.advisories)
+    ? (body.advisories as unknown[]).filter((a): a is string => typeof a === 'string')
+    : undefined;
 
   try {
     const project = getProject(id);
@@ -36,7 +41,10 @@ export async function POST(
 
       // Remote has commits we don't have (e.g. Dependabot merged between our commit and push).
       // Rebase our patch commit on top of whatever landed remotely, then push again.
-      logger.info('git', 'push_rebase', 'Push rejected (non-fast-forward) — pulling with rebase', { projectId: id });
+      logger.info('git', 'push_rebase', 'Push rejected (non-fast-forward) — pulling with rebase', {
+        projectId: id,
+        meta: { ...(source ? { source } : {}), ...(advisories ? { advisories } : {}) },
+      });
       try {
         await execFileAsync('git', ['pull', '--rebase', '--autostash'], { cwd, timeout: 60000 });
       } catch (pullErr) {
@@ -50,6 +58,7 @@ export async function POST(
     // Log success
     logger.info('git', 'push_completed', 'Pushed changes to remote', {
       projectId: id,
+      meta: { ...(source ? { source } : {}), ...(advisories ? { advisories } : {}) },
     });
 
     return NextResponse.json({
@@ -64,7 +73,11 @@ export async function POST(
     // Log failure
     logger.error('git', 'push_failed', `Push failed: ${errorMessage}`, {
       projectId: id,
-      meta: { error: errorMessage },
+      meta: {
+        error: errorMessage,
+        ...(source ? { source } : {}),
+        ...(advisories ? { advisories } : {}),
+      },
     });
 
     return NextResponse.json(

--- a/src/app/api/projects/[id]/update/route.ts
+++ b/src/app/api/projects/[id]/update/route.ts
@@ -32,6 +32,7 @@ interface UpdateRequestBody {
     fixByParent?: { name: string; version: string };
   }>;
   lockfileResolution?: LockfileResolutionMode;
+  auditContext?: { source?: string; advisories?: string[]; severity?: string };
 }
 
 export async function POST(
@@ -322,6 +323,22 @@ export async function POST(
           }
         }
       } catch { /* non-fatal */ }
+    }
+
+    // Origin-tagged remediation audit trail (e.g. applied from the CVE Lite dashboard).
+    if (anySucceeded && body.auditContext?.source) {
+      const successfulNames = results.filter(r => r.success).map(r => r.package).filter(n => n !== '*');
+      logger.info('patches', 'security_remediation_applied',
+        `Applied security fix in ${id}: ${successfulNames.join(', ') || '(reconcile)'}`,
+        {
+          projectId: id,
+          meta: {
+            source: body.auditContext.source,
+            advisories: body.auditContext.advisories ?? [],
+            severity: body.auditContext.severity,
+            packages: successfulNames,
+          },
+        });
     }
 
     const allSucceeded = results.every(r => r.success);

--- a/src/app/api/security/cve-lite/[id]/fix/route.ts
+++ b/src/app/api/security/cve-lite/[id]/fix/route.ts
@@ -31,6 +31,7 @@ export async function POST(
   if (body.mode !== 'all') {
     return NextResponse.json({ error: "mode must be 'all'" }, { status: 400 });
   }
+  const auditContext = body.auditContext as { source?: string; advisories?: string[]; severity?: string } | undefined;
   let summary = '';
   let ok = true;
   try {
@@ -48,5 +49,15 @@ export async function POST(
   await runCveLite(project, { force: true }).catch(() => {});
   await runSecurityScan(project).catch(() => {});
   logger.info('api', 'cve_lite_fix', `cve-lite --fix on ${id} (ok=${ok})`, { projectId: id });
+  if (ok && auditContext?.source) {
+    logger.info('patches', 'security_remediation_applied', `Applied cve-lite --fix in ${id}`, {
+      projectId: id,
+      meta: {
+        source: auditContext.source,
+        advisories: auditContext.advisories ?? [],
+        severity: auditContext.severity,
+      },
+    });
+  }
   return NextResponse.json({ ok, summary, rescanned: true });
 }

--- a/src/app/security/page.tsx
+++ b/src/app/security/page.tsx
@@ -130,11 +130,22 @@ function SecurityHubInner() {
 
   const beginPendingCommit = useCallback(
     async (rc: { packages: UpdatedPackage[]; advisories: string[]; severity?: string }) => {
+      const status = await fetchGitStatus(selected);
+      setGitStatus(status);
+      // An apply can produce nothing to commit: "Fix all direct" (cve-lite --fix) on a
+      // transitive-only advisory is a no-op, and some fixes only touch gitignored node_modules.
+      // Don't open a commit banner that would dead-end on "No changes to commit".
+      if (!status?.dirty) {
+        setPendingCommit(null);
+        setCommitted(false);
+        setError('Fix ran, but there were no file changes to commit. A transitive advisory cannot be fixed by "Fix all direct" — use the per-finding Apply, which adds a package override.');
+        return;
+      }
+      setError(null);
       const generated = generatePatchCommitMessage(rc.packages).full;
       const message = generated || `chore(deps): apply cve-lite fixes in ${selected}`;
       setPendingCommit({ ...rc, message, isEditing: false });
       setCommitted(false);
-      setGitStatus(await fetchGitStatus(selected));
     },
     [selected, fetchGitStatus],
   );

--- a/src/app/security/page.tsx
+++ b/src/app/security/page.tsx
@@ -206,7 +206,9 @@ function SecurityHubInner() {
       </>
     ),
     run: async () => {
-      const rc = remediationFromRows(rows);
+      // Audit context covers all direct fixable findings — `cve-lite --fix` ignores the
+      // importedOnly/reachability filter, so derive from the unfiltered report, not `rows`.
+      const rc = remediationFromRows(report ? findingRows(report) : []);
       const res = await fetch(`/api/security/cve-lite/${selected}/fix`, {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ mode: 'all', auditContext: { source: 'cve-lite', advisories: rc.advisories, severity: rc.severity } }),

--- a/src/app/security/page.tsx
+++ b/src/app/security/page.tsx
@@ -16,8 +16,20 @@ import { CveLiteManage } from '@/components/security/cve-lite/cve-lite-manage';
 import { SourceStrip } from '@/components/security/source-strip';
 import { ConfirmDialog } from '@/components/security/cve-lite/confirm-dialog';
 import { AUTO_APPLY_ENABLED } from '@/lib/auto-apply-flag';
+import type { UpdatedPackage } from '@/lib/patch-commit-message';
+import { generatePatchCommitMessage } from '@/lib/patch-commit-message';
+import { remediationFromRow, remediationFromRows } from '@/lib/security/remediation-commit';
+import { PendingCommitBanner } from '@/components/security/cve-lite/pending-commit-banner';
 
 interface ConfirmState { title: string; body: ReactNode; run: () => Promise<void> }
+interface GitStatus { branch: string; ahead: number; behind: number; dirty: boolean }
+interface PendingCommit {
+  packages: UpdatedPackage[];
+  advisories: string[];
+  severity?: string;
+  message: string;
+  isEditing: boolean;
+}
 
 function SecurityHubInner() {
   const searchParams = useSearchParams();
@@ -35,6 +47,11 @@ function SecurityHubInner() {
   const [dbStatus, setDbStatus] = useState<DbStatus | null>(null);
   const [confirm, setConfirm] = useState<ConfirmState | null>(null);
   const [busy, setBusy] = useState(false);
+  const [pendingCommit, setPendingCommit] = useState<PendingCommit | null>(null);
+  const [gitStatus, setGitStatus] = useState<GitStatus | null>(null);
+  const [isCommitting, setIsCommitting] = useState(false);
+  const [isPushing, setIsPushing] = useState(false);
+  const [committed, setCommitted] = useState(false);
 
   const refreshRail = useCallback(() => {
     fetch('/api/security/cve-lite/summary')
@@ -100,6 +117,74 @@ function SecurityHubInner() {
 
   useEffect(() => { load(false); }, [load]);
 
+  const fetchGitStatus = useCallback(async (projectId: string): Promise<GitStatus | null> => {
+    try {
+      const res = await fetch(`/api/projects/${projectId}/git`);
+      if (!res.ok) return null;
+      const d = await res.json();
+      return { branch: d.branch ?? '', ahead: d.aheadCount ?? 0, behind: d.behindCount ?? 0, dirty: !!d.isDirty };
+    } catch {
+      return null;
+    }
+  }, []);
+
+  const beginPendingCommit = useCallback(
+    async (rc: { packages: UpdatedPackage[]; advisories: string[]; severity?: string }) => {
+      const generated = generatePatchCommitMessage(rc.packages).full;
+      const message = generated || `chore(deps): apply cve-lite fixes in ${selected}`;
+      setPendingCommit({ ...rc, message, isEditing: false });
+      setCommitted(false);
+      setGitStatus(await fetchGitStatus(selected));
+    },
+    [selected, fetchGitStatus],
+  );
+
+  const handleCommit = useCallback(async () => {
+    if (!pendingCommit) return;
+    setIsCommitting(true); setError(null);
+    try {
+      const res = await fetch(`/api/projects/${selected}/git-commit`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: pendingCommit.message, source: 'cve-lite', advisories: pendingCommit.advisories }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || data.success === false) throw new Error(data.error ?? `commit failed (HTTP ${res.status})`);
+      setCommitted(true);
+      setPendingCommit((pc) => (pc ? { ...pc, isEditing: false } : pc));
+      setGitStatus(await fetchGitStatus(selected));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'commit failed');
+    } finally {
+      setIsCommitting(false);
+    }
+  }, [pendingCommit, selected, fetchGitStatus]);
+
+  const handlePush = useCallback(async () => {
+    if (!pendingCommit) return;
+    setIsPushing(true); setError(null);
+    try {
+      const res = await fetch(`/api/projects/${selected}/git-push`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ source: 'cve-lite', advisories: pendingCommit.advisories }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || data.success === false) throw new Error(data.error ?? `push failed (HTTP ${res.status})`);
+      setPendingCommit(null); setCommitted(false);
+      setGitStatus(await fetchGitStatus(selected));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'push failed');
+    } finally {
+      setIsPushing(false);
+    }
+  }, [pendingCommit, selected, fetchGitStatus]);
+
+  // Clear any pending commit when the user switches projects.
+  useEffect(() => {
+    setPendingCommit(null);
+    setCommitted(false);
+    setGitStatus(null);
+  }, [selected]);
+
   const runConfirmed = async () => {
     if (!confirm) return;
     setBusy(true); setError(null);
@@ -121,13 +206,15 @@ function SecurityHubInner() {
       </>
     ),
     run: async () => {
+      const rc = remediationFromRows(rows);
       const res = await fetch(`/api/security/cve-lite/${selected}/fix`, {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ mode: 'all' }),
+        body: JSON.stringify({ mode: 'all', auditContext: { source: 'cve-lite', advisories: rc.advisories, severity: rc.severity } }),
       });
       const data = await res.json().catch(() => ({}));
       if (!res.ok || data.ok === false) throw new Error(data.error ?? data.summary ?? `fix failed (HTTP ${res.status})`);
       await load(true);
+      await beginPendingCommit(rc);
     },
   });
 
@@ -140,6 +227,7 @@ function SecurityHubInner() {
       </>
     ),
     run: async () => {
+      const rc = remediationFromRow(row);
       const res = await fetch(`/api/projects/${selected}/update`, {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -149,6 +237,7 @@ function SecurityHubInner() {
             toVersion: row.validatedFixVersion,
             fixViaOverride: row.relationship === 'transitive',
           }],
+          auditContext: { source: 'cve-lite', advisories: rc.advisories, severity: rc.severity },
         }),
       });
       if (!res.ok) {
@@ -156,6 +245,7 @@ function SecurityHubInner() {
         throw new Error(e.error ?? `update failed (HTTP ${res.status})`);
       }
       await load(true);
+      await beginPendingCommit(rc);
     },
   });
 
@@ -215,6 +305,22 @@ function SecurityHubInner() {
             onRescan={() => load(true)}
           />
         </div>
+        {pendingCommit && AUTO_APPLY_ENABLED && (
+          <PendingCommitBanner
+            packages={pendingCommit.packages}
+            message={pendingCommit.message}
+            isEditing={pendingCommit.isEditing}
+            ahead={gitStatus?.ahead ?? 0}
+            committed={committed}
+            isCommitting={isCommitting}
+            isPushing={isPushing}
+            onMessageChange={(msg) => setPendingCommit((pc) => (pc ? { ...pc, message: msg } : pc))}
+            onToggleEdit={() => setPendingCommit((pc) => (pc ? { ...pc, isEditing: !pc.isEditing } : pc))}
+            onCommit={handleCommit}
+            onPush={handlePush}
+            onDismiss={() => { setPendingCommit(null); setCommitted(false); }}
+          />
+        )}
         {loading && <div className="text-sm text-zinc-500">Scanning…</div>}
         {error && <div className="text-sm text-red-400">{error}</div>}
         {!loading && !error && visibleReport && (

--- a/src/components/security/cve-lite/pending-commit-banner.tsx
+++ b/src/components/security/cve-lite/pending-commit-banner.tsx
@@ -1,0 +1,96 @@
+'use client';
+import type { UpdatedPackage } from '@/lib/patch-commit-message';
+
+export interface PendingCommitBannerProps {
+  packages: UpdatedPackage[];
+  message: string;
+  isEditing: boolean;
+  ahead: number;
+  committed: boolean;
+  isCommitting: boolean;
+  isPushing: boolean;
+  onMessageChange: (msg: string) => void;
+  onToggleEdit: () => void;
+  onCommit: () => void;
+  onPush: () => void;
+  onDismiss: () => void;
+}
+
+export function PendingCommitBanner({
+  packages,
+  message,
+  isEditing,
+  ahead,
+  committed,
+  isCommitting,
+  isPushing,
+  onMessageChange,
+  onToggleEdit,
+  onCommit,
+  onPush,
+  onDismiss,
+}: PendingCommitBannerProps) {
+  const securityCount = packages.filter((p) => p.isSecurityFix).length;
+
+  return (
+    <div className="border border-purple-800/60 bg-purple-950/20 rounded-md p-3 space-y-2 text-xs">
+      <div className="flex items-center justify-between">
+        <span className="text-purple-200 font-medium">
+          {committed ? 'Committed — ready to push' : 'Fix applied — ready to commit'}
+          {securityCount > 0 && (
+            <span className="ml-2 text-purple-400">
+              ({securityCount} security fix{securityCount !== 1 ? 'es' : ''})
+            </span>
+          )}
+        </span>
+        <button type="button" onClick={onDismiss} className="text-zinc-500 hover:text-zinc-300">
+          Dismiss
+        </button>
+      </div>
+
+      {isEditing ? (
+        <textarea
+          value={message}
+          onChange={(e) => onMessageChange(e.target.value)}
+          rows={Math.min(8, message.split('\n').length + 1)}
+          className="w-full bg-zinc-950 border border-zinc-700 rounded px-2 py-1 font-mono text-[11px] text-zinc-200"
+        />
+      ) : (
+        <pre className="whitespace-pre-wrap font-mono text-[11px] text-zinc-300 bg-zinc-950/50 rounded px-2 py-1">
+          {message}
+        </pre>
+      )}
+
+      <div className="flex items-center gap-2">
+        {!committed && (
+          <button
+            type="button"
+            onClick={onToggleEdit}
+            className="px-2 py-0.5 rounded border border-zinc-700 text-zinc-300 hover:bg-zinc-800"
+          >
+            {isEditing ? 'Done editing' : 'Edit message'}
+          </button>
+        )}
+        {!committed ? (
+          <button
+            type="button"
+            onClick={onCommit}
+            disabled={isCommitting || !message.trim()}
+            className="px-2 py-0.5 rounded border border-green-700 text-green-300 hover:bg-green-900/30 disabled:opacity-40"
+          >
+            {isCommitting ? 'Committing…' : 'Commit'}
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={onPush}
+            disabled={isPushing || ahead === 0}
+            className="px-2 py-0.5 rounded border border-blue-700 text-blue-300 hover:bg-blue-900/30 disabled:opacity-40"
+          >
+            {isPushing ? 'Pushing…' : ahead > 0 ? `Push (${ahead})` : 'Push'}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/security/cve-lite-db.ts
+++ b/src/lib/security/cve-lite-db.ts
@@ -6,7 +6,14 @@ import { homedir } from 'os';
 
 const execAsync = promisify(exec);
 const BIN = join(process.cwd(), 'node_modules', '.bin', 'cve-lite');
-const DB_FILE = join(homedir(), '.cache', 'cve-lite', 'osv-vulns.json');
+
+/**
+ * The local advisory database that `cve-lite advisories sync` writes (its
+ * `--output` default) and that `cve-lite --offline-db` reads. The status check,
+ * the sync, and the offline scan fallback must all agree on this one path —
+ * the legacy `osv-vulns.json` is a query-cache artifact `sync` never updates.
+ */
+export const CVE_LITE_DB_PATH = join(homedir(), '.cache', 'cve-lite', 'advisories.db');
 
 export interface DbStatus { ok: boolean; synced: boolean; builtAt?: string; ageDays?: number }
 
@@ -18,8 +25,8 @@ export function dbStatusFromMtime(mtimeMs: number | null): DbStatus {
 
 export function readDbStatus(): DbStatus {
   try {
-    if (!existsSync(DB_FILE)) return dbStatusFromMtime(null);
-    return dbStatusFromMtime(statSync(DB_FILE).mtimeMs);
+    if (!existsSync(CVE_LITE_DB_PATH)) return dbStatusFromMtime(null);
+    return dbStatusFromMtime(statSync(CVE_LITE_DB_PATH).mtimeMs);
   } catch {
     return dbStatusFromMtime(null);
   }

--- a/src/lib/security/cve-lite-view.ts
+++ b/src/lib/security/cve-lite-view.ts
@@ -1,7 +1,7 @@
 import type { CveLiteOutput, CveLiteFinding } from './sources/cve-lite';
 
 export type FixSeverity = 'critical' | 'high' | 'medium' | 'low';
-const ORDER: FixSeverity[] = ['critical', 'high', 'medium', 'low'];
+export const FIX_SEVERITY_ORDER: FixSeverity[] = ['critical', 'high', 'medium', 'low'];
 
 function normSeverity(s?: string): FixSeverity {
   const v = (s ?? 'low').toLowerCase();
@@ -53,7 +53,7 @@ export function selectFixPlan(report: CveLiteOutput): FixPlanGroup[] {
     }
   }
   const groups: FixPlanGroup[] = [];
-  for (const sev of ORDER) {
+  for (const sev of FIX_SEVERITY_ORDER) {
     const g = bySeverity.get(sev);
     if (g && g.size > 0) groups.push({ severity: sev, items: Array.from(g.values()) });
   }

--- a/src/lib/security/remediation-commit.test.ts
+++ b/src/lib/security/remediation-commit.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { remediationFromRow, remediationFromRows } from './remediation-commit';
+import type { FindingRow } from './cve-lite-view';
+
+function row(over: Partial<FindingRow> = {}): FindingRow {
+  return {
+    package: 'qs',
+    version: '6.15.1',
+    severity: 'medium',
+    relationship: 'transitive',
+    validatedFixVersion: '6.15.2',
+    advisoryIds: ['GHSA-q8mj-m7cp-5q26', 'CVE-2026-8723'],
+    ...over,
+  };
+}
+
+describe('remediationFromRow', () => {
+  it('builds one security UpdatedPackage from a row', () => {
+    const rc = remediationFromRow(row());
+    expect(rc.packages).toEqual([
+      { name: 'qs', fromVersion: '6.15.1', toVersion: '6.15.2', isSecurityFix: true, vulnCount: 2 },
+    ]);
+    expect(rc.advisories).toEqual(['GHSA-q8mj-m7cp-5q26', 'CVE-2026-8723']);
+    expect(rc.severity).toBe('medium');
+  });
+
+  it('de-dupes advisory ids', () => {
+    const rc = remediationFromRow(row({ advisoryIds: ['CVE-1', 'CVE-1', 'GHSA-x'] }));
+    expect(rc.advisories).toEqual(['CVE-1', 'GHSA-x']);
+    expect(rc.packages[0].vulnCount).toBe(3);
+  });
+
+  it('tolerates missing versions', () => {
+    const rc = remediationFromRow(row({ version: undefined, validatedFixVersion: undefined }));
+    expect(rc.packages[0].fromVersion).toBe('');
+    expect(rc.packages[0].toVersion).toBe('');
+  });
+});
+
+describe('remediationFromRows', () => {
+  it('keeps only direct, fixable rows', () => {
+    const rows = [
+      row({ package: 'a', relationship: 'direct', validatedFixVersion: '2.0.0', advisoryIds: ['CVE-A'], severity: 'high' }),
+      row({ package: 'b', relationship: 'transitive', validatedFixVersion: '2.0.0' }),
+      row({ package: 'c', relationship: 'direct', validatedFixVersion: undefined }),
+    ];
+    const rc = remediationFromRows(rows);
+    expect(rc.packages.map((p) => p.name)).toEqual(['a']);
+  });
+
+  it('unions advisories and takes the max severity', () => {
+    const rows = [
+      row({ package: 'a', relationship: 'direct', validatedFixVersion: '2.0.0', advisoryIds: ['CVE-A'], severity: 'medium' }),
+      row({ package: 'd', relationship: 'direct', validatedFixVersion: '3.0.0', advisoryIds: ['CVE-D', 'CVE-A'], severity: 'critical' }),
+    ];
+    const rc = remediationFromRows(rows);
+    expect(rc.advisories).toEqual(['CVE-A', 'CVE-D']);
+    expect(rc.severity).toBe('critical');
+  });
+
+  it('returns empty when nothing is fixable', () => {
+    const rc = remediationFromRows([row({ relationship: 'transitive' })]);
+    expect(rc.packages).toEqual([]);
+    expect(rc.advisories).toEqual([]);
+    expect(rc.severity).toBeUndefined();
+  });
+});

--- a/src/lib/security/remediation-commit.ts
+++ b/src/lib/security/remediation-commit.ts
@@ -1,4 +1,5 @@
 import type { FindingRow, FixSeverity } from './cve-lite-view';
+import { FIX_SEVERITY_ORDER } from './cve-lite-view';
 import type { UpdatedPackage } from '@/lib/patch-commit-message';
 
 export interface RemediationCommit {
@@ -10,12 +11,10 @@ export interface RemediationCommit {
   severity?: FixSeverity;
 }
 
-const SEVERITY_ORDER: FixSeverity[] = ['critical', 'high', 'medium', 'low'];
-
 function maxSeverity(severities: FixSeverity[]): FixSeverity | undefined {
   let best: FixSeverity | undefined;
   for (const s of severities) {
-    if (best === undefined || SEVERITY_ORDER.indexOf(s) < SEVERITY_ORDER.indexOf(best)) {
+    if (best === undefined || FIX_SEVERITY_ORDER.indexOf(s) < FIX_SEVERITY_ORDER.indexOf(best)) {
       best = s;
     }
   }

--- a/src/lib/security/remediation-commit.ts
+++ b/src/lib/security/remediation-commit.ts
@@ -1,0 +1,55 @@
+import type { FindingRow, FixSeverity } from './cve-lite-view';
+import type { UpdatedPackage } from '@/lib/patch-commit-message';
+
+export interface RemediationCommit {
+  /** Feeds generatePatchCommitMessage. */
+  packages: UpdatedPackage[];
+  /** De-duped advisory IDs (GHSA + CVE) for the audit trail. */
+  advisories: string[];
+  /** Highest severity among the included rows. */
+  severity?: FixSeverity;
+}
+
+const SEVERITY_ORDER: FixSeverity[] = ['critical', 'high', 'medium', 'low'];
+
+function maxSeverity(severities: FixSeverity[]): FixSeverity | undefined {
+  let best: FixSeverity | undefined;
+  for (const s of severities) {
+    if (best === undefined || SEVERITY_ORDER.indexOf(s) < SEVERITY_ORDER.indexOf(best)) {
+      best = s;
+    }
+  }
+  return best;
+}
+
+function pkgFromRow(row: FindingRow): UpdatedPackage {
+  return {
+    name: row.package,
+    fromVersion: row.version ?? '',
+    toVersion: row.validatedFixVersion ?? '',
+    isSecurityFix: true,
+    vulnCount: row.advisoryIds.length,
+  };
+}
+
+/** Build a remediation commit from a single applied finding row (applyOne). */
+export function remediationFromRow(row: FindingRow): RemediationCommit {
+  return {
+    packages: [pkgFromRow(row)],
+    advisories: [...new Set(row.advisoryIds)],
+    severity: row.severity,
+  };
+}
+
+/**
+ * Build a remediation commit from all displayed rows, filtered to what
+ * `cve-lite --fix` (mode `all`) addresses: direct deps with a validated fix.
+ */
+export function remediationFromRows(rows: FindingRow[]): RemediationCommit {
+  const fixable = rows.filter((r) => r.relationship === 'direct' && r.validatedFixVersion);
+  return {
+    packages: fixable.map(pkgFromRow),
+    advisories: [...new Set(fixable.flatMap((r) => r.advisoryIds))],
+    severity: maxSeverity(fixable.map((r) => r.severity)),
+  };
+}

--- a/src/lib/security/sources/cve-lite.test.ts
+++ b/src/lib/security/sources/cve-lite.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { parseCveLiteJson, buildScanFlags } from './cve-lite';
+import { parseCveLiteJson, buildScanFlags, buildCveLiteCommand } from './cve-lite';
+import { CVE_LITE_DB_PATH } from '../cve-lite-db';
 
 const fixture = JSON.parse(readFileSync(join(__dirname, '__fixtures__/cve-lite-sample.json'), 'utf-8'));
 
@@ -75,5 +76,34 @@ describe('buildScanFlags', () => {
 	});
 	it('combines flags in a stable order', () => {
 		expect(buildScanFlags({ minSeverity: 'critical', all: true })).toEqual(['--min-severity', 'critical', '--all']);
+	});
+});
+
+describe('buildCveLiteCommand', () => {
+	it('online (default) emits --json --usage and the project path, no offline flags', () => {
+		const cmd = buildCveLiteCommand('/bin/cve-lite', '/proj', []);
+		expect(cmd).toBe('"/bin/cve-lite" "--json" "--usage" "/proj"');
+		expect(cmd).not.toContain('--offline');
+	});
+
+	it('offline appends --offline-db pointing at the synced advisory DB', () => {
+		const cmd = buildCveLiteCommand('/bin/cve-lite', '/proj', [], { offline: true });
+		expect(cmd).toContain('"--offline-db"');
+		expect(cmd).toContain(JSON.stringify(CVE_LITE_DB_PATH));
+	});
+
+	it('offline honors an explicit dbPath override', () => {
+		const cmd = buildCveLiteCommand('/bin/cve-lite', '/proj', [], { offline: true, dbPath: '/tmp/db' });
+		expect(cmd).toContain('"--offline-db" "/tmp/db"');
+	});
+
+	it('threads scan flags through before the project path', () => {
+		const cmd = buildCveLiteCommand('/bin/cve-lite', '/proj', ['--min-severity', 'high']);
+		expect(cmd).toBe('"/bin/cve-lite" "--json" "--usage" "--min-severity" "high" "/proj"');
+	});
+
+	it('quotes every argument (paths with spaces are safe)', () => {
+		const cmd = buildCveLiteCommand('/bin/cve-lite', '/my proj', []);
+		expect(cmd).toContain('"/my proj"');
 	});
 });

--- a/src/lib/security/sources/cve-lite.ts
+++ b/src/lib/security/sources/cve-lite.ts
@@ -7,6 +7,7 @@ import type { ScanSource, Finding, Severity, Remediation } from '../types';
 import type { ProjectConfig } from '../../types';
 import { readCveLiteCache, writeCveLiteCache } from '../cve-lite-cache';
 import { deriveReachable } from '../cve-lite-view';
+import { CVE_LITE_DB_PATH } from '../cve-lite-db';
 
 const execAsync = promisify(exec);
 
@@ -145,22 +146,75 @@ async function probe(): Promise<boolean> {
 	return availableCache;
 }
 
-/** Runs cve-lite once and returns the full report (no caching). */
+/**
+ * Builds the cve-lite scan command. With `offline: true` it appends
+ * `--offline-db <dbPath>` so cve-lite reads the synced local advisory DB
+ * instead of querying the live OSV API.
+ */
+export function buildCveLiteCommand(
+	bin: string,
+	projectPath: string,
+	flags: string[],
+	opts: { offline?: boolean; dbPath?: string } = {},
+): string {
+	const parts = ['--json', '--usage', ...flags];
+	if (opts.offline) parts.push('--offline-db', opts.dbPath ?? CVE_LITE_DB_PATH);
+	parts.push(projectPath);
+	return [bin, ...parts].map((p) => JSON.stringify(p)).join(' ');
+}
+
+/**
+ * Runs one cve-lite invocation in `tmpDir`. Returns the parsed report, or null
+ * if no output file was written — which is the signal that the scan failed
+ * (e.g. the live OSV fetch failed). cve-lite also exits non-zero when findings
+ * exist, but in that case the JSON file IS written, so the file's presence —
+ * not the exit code — is what distinguishes success from failure.
+ */
+async function runScanAttempt(
+	tmpDir: string,
+	projectPath: string,
+	flags: string[],
+	opts: { offline?: boolean },
+): Promise<CveLiteOutput | null> {
+	try {
+		await execAsync(buildCveLiteCommand(binPath(), projectPath, flags, opts), {
+			cwd: tmpDir,
+			timeout: 170_000,
+			maxBuffer: 64 * 1024 * 1024,
+		});
+	} catch {
+		// Non-zero exit is expected when findings exist (file still written) and
+		// when the OSV fetch fails (no file written). Disambiguated below.
+	}
+	const outFile = readdirSync(tmpDir).find((f) => f.startsWith('cve-lite-scan-') && f.endsWith('.json'));
+	if (!outFile) return null;
+	return JSON.parse(readFileSync(join(tmpDir, outFile), 'utf-8')) as CveLiteOutput;
+}
+
+/**
+ * Runs cve-lite once and returns the full report (no caching). Tries online
+ * first (freshest OSV data); if that yields no output — which happens when the
+ * live OSV API is unreachable (offline/air-gapped/restricted networks) — it
+ * falls back to an offline scan against the synced advisory DB. Throws if
+ * neither attempt produces output, rather than silently reporting zero
+ * findings, so the caller surfaces a real error instead of a false all-clear.
+ */
 export async function runCveLiteRaw(project: ProjectConfig, options: ScanOptions = {}): Promise<CveLiteOutput> {
 	const tmp = mkdtempSync(join(tmpdir(), 'hexops-cve-lite-'));
 	try {
-		const flags = buildScanFlags(options).map((f) => JSON.stringify(f)).join(' ');
-		try {
-			await execAsync(
-				`${JSON.stringify(binPath())} --json --usage ${flags} ${JSON.stringify(project.path)}`,
-				{ cwd: tmp, timeout: 170_000, maxBuffer: 64 * 1024 * 1024 },
-			);
-		} catch {
-			// cve-lite may exit non-zero when findings exist; the JSON file is still written.
+		const flags = buildScanFlags(options);
+		const online = await runScanAttempt(tmp, project.path, flags, { offline: false });
+		if (online) return online;
+		const haveDb = existsSync(CVE_LITE_DB_PATH);
+		if (haveDb) {
+			const offline = await runScanAttempt(tmp, project.path, flags, { offline: true });
+			if (offline) return offline;
 		}
-		const outFile = readdirSync(tmp).find((f) => f.startsWith('cve-lite-scan-') && f.endsWith('.json'));
-		if (!outFile) return { findings: [] };
-		return JSON.parse(readFileSync(join(tmp, outFile), 'utf-8')) as CveLiteOutput;
+		throw new Error(
+			haveDb
+				? 'cve-lite produced no output (online OSV query and offline DB scan both failed)'
+				: 'cve-lite produced no output: OSV API unreachable and no local advisory DB — run Sync DB first',
+		);
 	} finally {
 		try { rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ }
 	}


### PR DESCRIPTION
## Summary

- Adds the Patches-style **Apply → Commit → Push** flow to the CVE Lite security dashboard (`/security`), scoped to the selected project, reusing the existing `/git-commit` and `/git-push` endpoints and `generatePatchCommitMessage`. No diff review; editable generated commit message; push stays a deliberate click.
- Emits an **origin-tagged remediation audit trail**: a `security_remediation_applied` log on apply (both per-finding **Apply** and **Fix all direct**), plus `source: 'cve-lite'` + advisory IDs folded into the existing `commit_created` / `push_completed` log meta. Net: *this CVE → this commit → pushed*.
- Guards the commit banner on actual **git-dirty** state, so a no-op apply (e.g. "Fix all direct" on a transitive-only advisory, which `cve-lite --fix` can't touch) explains itself instead of dead-ending on "No changes to commit".
- Also includes the prerequisite **CVE Lite offline-fallback fix (#105/#106)**: cve-lite now falls back to the synced advisory DB (`--offline-db`) when the OSV API is unreachable (previously it failed silently and reported zero findings), and the DB-status indicator reads `advisories.db` — the file `advisories sync` actually writes.

## Changes

- **New** `src/lib/security/remediation-commit.ts` (+ tests) — pure helper deriving commit packages + de-duped advisory IDs from `FindingRow` (`remediationFromRow`, `remediationFromRows`).
- **New** `src/components/security/cve-lite/pending-commit-banner.tsx` — self-contained Commit/Push banner.
- `src/app/security/page.tsx` — apply→commit→push wiring, audit context, dirty-gated banner.
- `update`, `cve-lite/[id]/fix`, `git-commit`, `git-push` routes — optional `auditContext` / `source` / `advisories` → logs (backward compatible; Patches page unaffected).
- `src/lib/security/cve-lite-view.ts` — extract shared `FIX_SEVERITY_ORDER`.
- `src/lib/security/sources/cve-lite.ts` + `cve-lite-db.ts` — online→offline fallback + correct DB path (#105/#106).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run` — 105 tests pass (incl. new `remediation-commit` + builder tests)
- [x] `pnpm build` succeeds
- [x] Manual: "Fix all direct" no-op on a transitive-only advisory shows the explanatory message and creates no bogus commit (verified via logs + clean tree)
- [ ] Manual: per-finding **Apply** on a transitive advisory → `pnpm.overrides` written → Commit → Push, and confirm the `security_remediation_applied` + `commit_created`/`push_completed` log trail carries `source: 'cve-lite'` + advisory IDs

Closes #105, #106, #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)