### PR TITLE
fix(overrides): emit >= security floors instead of exact pins

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-apexcharts": "^2.1.1",
     "react-dom": "19.2.7",
     "recharts": "^3.8.1",
+    "semver": "^7.8.5",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "ws": "^8.21.0"
@@ -66,6 +67,7 @@
     "@types/node": "^26.0.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@types/semver": "^7.8.0",
     "@types/ws": "^8.18.1",
     "@vitest/ui": "^4.1.9",
     "cve-lite-cli": "1.28.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       recharts:
         specifier: ^3.8.1
         version: 3.8.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1)
+      semver:
+        specifier: ^7.8.5
+        version: 7.8.5
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -105,6 +108,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      '@types/semver':
+        specifier: ^7.8.0
+        version: 7.8.0
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -1589,6 +1595,9 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/semver@7.8.0':
+    resolution: {integrity: sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==}
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
@@ -4061,6 +4070,8 @@ snapshots:
   '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
+
+  '@types/semver@7.8.0': {}
 
   '@types/use-sync-external-store@0.0.6': {}
 

--- a/src/app/api/projects/[id]/update/route.enabled.test.ts
+++ b/src/app/api/projects/[id]/update/route.enabled.test.ts
@@ -38,7 +38,7 @@ vi.mock('@/lib/updaters/override', () => ({
   removeOverrideConflicts: vi.fn(),
   cleanStaleOverrides: vi.fn(),
   findAllInstalledVersions: vi.fn().mockReturnValue({ root: undefined, all: [] }),
-  pickPrimaryVersion: vi.fn().mockReturnValue(undefined),
+  pickLowestVersion: vi.fn().mockReturnValue(undefined),
 }));
 vi.mock('@/lib/updaters/install', () => ({ installPackages: vi.fn() }));
 

--- a/src/app/api/projects/[id]/update/route.enabled.test.ts
+++ b/src/app/api/projects/[id]/update/route.enabled.test.ts
@@ -37,6 +37,8 @@ vi.mock('@/lib/updaters/override', () => ({
   applyOverrides: vi.fn(),
   removeOverrideConflicts: vi.fn(),
   cleanStaleOverrides: vi.fn(),
+  findAllInstalledVersions: vi.fn().mockReturnValue({ root: undefined, all: [] }),
+  pickPrimaryVersion: vi.fn().mockReturnValue(undefined),
 }));
 vi.mock('@/lib/updaters/install', () => ({ installPackages: vi.fn() }));
 

--- a/src/app/api/projects/[id]/update/route.guard.test.ts
+++ b/src/app/api/projects/[id]/update/route.guard.test.ts
@@ -47,6 +47,8 @@ vi.mock('@/lib/updaters/override', () => ({
   applyOverrides: vi.fn(),
   removeOverrideConflicts: vi.fn(),
   cleanStaleOverrides: vi.fn(),
+  findAllInstalledVersions: vi.fn().mockReturnValue({ root: undefined, all: [] }),
+  pickPrimaryVersion: vi.fn().mockReturnValue(undefined),
 }));
 vi.mock('@/lib/updaters/install', () => ({ installPackages: vi.fn() }));
 

--- a/src/app/api/projects/[id]/update/route.guard.test.ts
+++ b/src/app/api/projects/[id]/update/route.guard.test.ts
@@ -48,7 +48,7 @@ vi.mock('@/lib/updaters/override', () => ({
   removeOverrideConflicts: vi.fn(),
   cleanStaleOverrides: vi.fn(),
   findAllInstalledVersions: vi.fn().mockReturnValue({ root: undefined, all: [] }),
-  pickPrimaryVersion: vi.fn().mockReturnValue(undefined),
+  pickLowestVersion: vi.fn().mockReturnValue(undefined),
 }));
 vi.mock('@/lib/updaters/install', () => ({ installPackages: vi.fn() }));
 

--- a/src/app/api/projects/[id]/update/route.test.ts
+++ b/src/app/api/projects/[id]/update/route.test.ts
@@ -35,6 +35,8 @@ vi.mock('@/lib/updaters/override', () => ({
   applyOverrides: vi.fn(),
   removeOverrideConflicts: vi.fn(),
   cleanStaleOverrides: vi.fn(),
+  findAllInstalledVersions: vi.fn().mockReturnValue({ root: undefined, all: [] }),
+  pickPrimaryVersion: vi.fn().mockReturnValue(undefined),
 }));
 vi.mock('@/lib/updaters/install', () => ({ installPackages: vi.fn() }));
 

--- a/src/app/api/projects/[id]/update/route.test.ts
+++ b/src/app/api/projects/[id]/update/route.test.ts
@@ -36,7 +36,7 @@ vi.mock('@/lib/updaters/override', () => ({
   removeOverrideConflicts: vi.fn(),
   cleanStaleOverrides: vi.fn(),
   findAllInstalledVersions: vi.fn().mockReturnValue({ root: undefined, all: [] }),
-  pickPrimaryVersion: vi.fn().mockReturnValue(undefined),
+  pickLowestVersion: vi.fn().mockReturnValue(undefined),
 }));
 vi.mock('@/lib/updaters/install', () => ({ installPackages: vi.fn() }));
 

--- a/src/app/api/projects/[id]/update/route.ts
+++ b/src/app/api/projects/[id]/update/route.ts
@@ -11,12 +11,12 @@ import { clearInMemoryCache } from '@/app/api/projects/[id]/package-health/route
 import { logger } from '@/lib/logger';
 import type { LockfileResolutionMode } from '@/lib/types';
 
-import { verifyAuditClear, type UpdatePackage } from '@/lib/updaters/common';
+import { verifyAuditClear, type UpdatePackage, type UpdateResult } from '@/lib/updaters/common';
 import { checkNodeModulesHealth, cleanNodeModules } from '@/lib/updaters/npm';
 import { checkPnpmLockfileHealth, repairPnpmLockfile, buildPnpmUpdateCmd } from '@/lib/updaters/pnpm';
 import { buildNpmUpdateCmd } from '@/lib/updaters/npm';
 import { buildYarnUpdateCmd } from '@/lib/updaters/yarn';
-import { applyOverrides, removeOverrideConflicts, cleanStaleOverrides } from '@/lib/updaters/override';
+import { applyOverrides, removeOverrideConflicts, cleanStaleOverrides, findAllInstalledVersions, pickPrimaryVersion } from '@/lib/updaters/override';
 import { installPackages } from '@/lib/updaters/install';
 import { execAsync } from '@/lib/updaters/common';
 import { SECURITY_PLUGINS } from '@/lib/security/plugins';
@@ -118,7 +118,7 @@ export async function POST(
       }
     } catch { /* ignore */ }
 
-    const results: Array<{ package: string; success: boolean; output: string; error?: string }> = [];
+    const results: UpdateResult[] = [];
 
     // Install-gate state — set when an installGate plugin rewrites the binary;
     // carried to the audit-trail log at the bottom of the closure.
@@ -162,10 +162,18 @@ export async function POST(
         let effectiveFromVersion = pkg.fromVersion || '';
         if (!effectiveFromVersion && !/^(latest|next|canary|resolve-latest)$/.test(targetVersion)) {
           try {
-            const nmPath = join(cwd, 'node_modules', pkg.name, 'package.json');
-            if (existsSync(nmPath)) {
-              effectiveFromVersion = JSON.parse(readFileSync(nmPath, 'utf-8')).version || '';
-            }
+            // A root-only node_modules read is the same isolated-linker blind
+            // spot fixed inside override.ts: packages requested here are
+            // frequently the transitive overrides applyOverrides manages, and
+            // on pnpm's default node-linker=isolated those have no root
+            // node_modules entry at all — they live in the .pnpm store
+            // instead. A root-only check silently leaves effectiveFromVersion
+            // empty on exactly the projects this whole round targeted, which
+            // in turn leaves the stale-tree guard in applyOverrides inert.
+            // Reuse the same lookup (root, then .pnpm store) rather than
+            // duplicating a second, narrower version of it here.
+            const { root, all } = findAllInstalledVersions(cwd, pkg.name);
+            effectiveFromVersion = pickPrimaryVersion(root, all) || '';
           } catch { /* fall through */ }
         }
         if (effectiveFromVersion && !/^(latest|next|canary|resolve-latest)$/.test(targetVersion)) {

--- a/src/app/api/projects/[id]/update/route.ts
+++ b/src/app/api/projects/[id]/update/route.ts
@@ -16,7 +16,7 @@ import { checkNodeModulesHealth, cleanNodeModules } from '@/lib/updaters/npm';
 import { checkPnpmLockfileHealth, repairPnpmLockfile, buildPnpmUpdateCmd } from '@/lib/updaters/pnpm';
 import { buildNpmUpdateCmd } from '@/lib/updaters/npm';
 import { buildYarnUpdateCmd } from '@/lib/updaters/yarn';
-import { applyOverrides, removeOverrideConflicts, cleanStaleOverrides, findAllInstalledVersions, pickPrimaryVersion } from '@/lib/updaters/override';
+import { applyOverrides, removeOverrideConflicts, cleanStaleOverrides, findAllInstalledVersions, pickLowestVersion } from '@/lib/updaters/override';
 import { installPackages } from '@/lib/updaters/install';
 import { execAsync } from '@/lib/updaters/common';
 import { SECURITY_PLUGINS } from '@/lib/security/plugins';
@@ -172,8 +172,19 @@ export async function POST(
             // in turn leaves the stale-tree guard in applyOverrides inert.
             // Reuse the same lookup (root, then .pnpm store) rather than
             // duplicating a second, narrower version of it here.
-            const { root, all } = findAllInstalledVersions(cwd, pkg.name);
-            effectiveFromVersion = pickPrimaryVersion(root, all) || '';
+            //
+            // Deliberately pickLowestVersion, NOT pickPrimaryVersion: this
+            // feeds the downgrade guard below, whose job is "is anything
+            // still below target" — the worst case across every copy — not
+            // "what's the one representative version". Feeding it the
+            // highest copy is actively wrong on a multi-copy isolated
+            // layout: a vulnerable 8.4.31 sitting next to a clean 8.5.30,
+            // against a target of 8.5.26, would read as "already past this
+            // fix" from the 8.5.30 copy and refuse the whole update —
+            // leaving the vulnerable 8.4.31 untouched. Refuse only when
+            // EVERY copy is already at or above the target.
+            const { all } = findAllInstalledVersions(cwd, pkg.name);
+            effectiveFromVersion = pickLowestVersion(all) || '';
           } catch { /* fall through */ }
         }
         if (effectiveFromVersion && !/^(latest|next|canary|resolve-latest)$/.test(targetVersion)) {

--- a/src/app/api/projects/[id]/update/route.ts
+++ b/src/app/api/projects/[id]/update/route.ts
@@ -177,7 +177,14 @@ export async function POST(
             continue;
           }
         }
-        validPackages.push({ name: pkg.name, fromVersion: pkg.fromVersion, targetVersion, fixViaOverride: pkg.fixViaOverride, fixByParent: pkg.fixByParent });
+        // Use effectiveFromVersion (falls back to reading node_modules when the
+        // request omitted fromVersion), not the raw request field. applyOverrides'
+        // stale-tree guard (override.ts) compares node_modules against fromVersion
+        // to tell "the install genuinely ran" apart from "node_modules was already
+        // in this state before we started" — if the raw (often-absent) request
+        // field is threaded through instead, that guard silently never fires for
+        // any request that omits fromVersion, which is the common case.
+        validPackages.push({ name: pkg.name, fromVersion: effectiveFromVersion || undefined, targetVersion, fixViaOverride: pkg.fixViaOverride, fixByParent: pkg.fixByParent });
       }
 
       // Separate transitive / override / direct packages

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -312,7 +312,17 @@ export interface PatchHistoryEntry {
   projectId: string;
   package: string;
   fromVersion: string;
+  /** The version that was targeted/requested — kept as-is; do not repurpose this to mean "what got installed". */
   toVersion: string;
+  /**
+   * The version actually found installed on disk after the patch, when it
+   * could be determined (see UpdateResult.resolvedVersion for the full
+   * rationale). Undefined, not defaulted to toVersion, when verification
+   * was inconclusive. With a `>=` floor override this can legitimately
+   * differ from toVersion — that's success, not a discrepancy to paper
+   * over by conflating the two fields.
+   */
+  resolvedVersion?: string;
   updateType: UpdateType;
   trigger: PatchTrigger;
   success: boolean;

--- a/src/lib/updaters/common.ts
+++ b/src/lib/updaters/common.ts
@@ -18,6 +18,18 @@ export interface UpdateResult {
   success: boolean;
   output: string;
   error?: string;
+  /**
+   * The version actually found installed on disk after an override was
+   * applied, when it could be determined. Distinct from the target version
+   * a caller requested: with a `>=` floor (no upper bound), the resolver is
+   * free to pick anything at or above the target, so `resolvedVersion` can
+   * — and often will — differ from the target that drove the override.
+   * Left undefined when it couldn't be determined (verification was
+   * inconclusive), not defaulted to the target — callers that care about
+   * the distinction should check for undefined rather than assume this
+   * always matches what was requested.
+   */
+  resolvedVersion?: string;
 }
 
 export async function verifyAuditClear(

--- a/src/lib/updaters/install.test.ts
+++ b/src/lib/updaters/install.test.ts
@@ -1,0 +1,112 @@
+// src/lib/updaters/install.test.ts
+//
+// Covers the "version unchanged after install" guard in installPackages
+// (the batch-install verification branch, ~line 139). That guard exists to
+// catch a package manager reporting success while silently not actually
+// updating anything. It used to fire whenever `installed.version ===
+// pkg.fromVersion`, full stop — which was safe only because route.ts almost
+// always passed `fromVersion: undefined` for requests that omitted it (a
+// raw request field, rarely populated by callers). Once route.ts started
+// passing the node_modules-read `effectiveFromVersion` instead (see
+// override.ts's isolated-linker fix and the accompanying route.ts change),
+// `fromVersion` can legitimately equal the pre-install installed version in
+// the benign "already at the target, re-requested from a stale scan cache"
+// case — and the unnarrowed guard would have reported that as a failure.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { UpdatePackage } from './common';
+
+const { execAsyncMock } = vi.hoisted(() => ({
+  execAsyncMock: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+}));
+vi.mock('./common', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./common')>();
+  return { ...actual, execAsync: execAsyncMock };
+});
+vi.mock('@/lib/patch-storage', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/patch-storage')>();
+  return { ...actual, addPatchHistoryEntry: vi.fn() };
+});
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { installPackages } from './install';
+
+const dirs: string[] = [];
+function makeTmpDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  dirs.push(dir);
+  return dir;
+}
+
+function writeInstalledVersion(dir: string, pkgName: string, version: string): void {
+  const pkgDir = join(dir, 'node_modules', pkgName);
+  mkdirSync(pkgDir, { recursive: true });
+  writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({ name: pkgName, version }), 'utf-8');
+}
+
+afterEach(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+  dirs.length = 0;
+  execAsyncMock.mockReset();
+  execAsyncMock.mockResolvedValue({ stdout: '', stderr: '' });
+});
+
+describe('installPackages — version-unchanged verification', () => {
+  it('does NOT report failure when the package is already at the requested target (benign no-op)', async () => {
+    const dir = makeTmpDir('hexops-install-alreadytarget-');
+    // Simulates: route.ts read the currently-installed version (8.5.26) as
+    // effectiveFromVersion because the request omitted fromVersion, and the
+    // requested target also happens to be 8.5.26 — e.g. a stale scan cache
+    // re-surfacing a patch that was already applied. The install command
+    // "succeeds" (exit 0) and, correctly, leaves the version unchanged.
+    writeInstalledVersion(dir, 'postcss', '8.5.26');
+
+    const pkgs: UpdatePackage[] = [{ name: 'postcss', fromVersion: '8.5.26', targetVersion: '8.5.26' }];
+    const results = await installPackages(pkgs, 'npm', false, dir, 'test-project');
+
+    expect(results[0].success).toBe(true);
+    expect(results[0].error).toBeUndefined();
+  });
+
+  it('still reports failure when the version genuinely did not change (real no-op)', async () => {
+    const dir = makeTmpDir('hexops-install-genuinefail-');
+    // fromVersion and the installed version match, but the TARGET was
+    // different — the install command exited 0 without actually doing
+    // anything. This is exactly the failure mode the guard exists to catch,
+    // and the narrowed guard must still catch it.
+    writeInstalledVersion(dir, 'postcss', '8.5.15');
+
+    const pkgs: UpdatePackage[] = [{ name: 'postcss', fromVersion: '8.5.15', targetVersion: '8.5.26' }];
+    const results = await installPackages(pkgs, 'npm', false, dir, 'test-project');
+
+    expect(results[0].success).toBe(false);
+    expect(results[0].error).toMatch(/version did not change/);
+  });
+
+  it('reports success for a normal update where the version actually moved', async () => {
+    const dir = makeTmpDir('hexops-install-normal-');
+    writeInstalledVersion(dir, 'postcss', '8.5.26');
+
+    const pkgs: UpdatePackage[] = [{ name: 'postcss', fromVersion: '8.5.15', targetVersion: '8.5.26' }];
+    const results = await installPackages(pkgs, 'npm', false, dir, 'test-project');
+
+    expect(results[0].success).toBe(true);
+  });
+
+  it('does not flag a floating-tag target (latest) as unchanged even if fromVersion happens to match', async () => {
+    const dir = makeTmpDir('hexops-install-floating-');
+    // A floating target is exempt from this guard entirely regardless of
+    // whether the installed version happens to equal fromVersion.
+    writeInstalledVersion(dir, 'postcss', '8.5.15');
+
+    const pkgs: UpdatePackage[] = [{ name: 'postcss', fromVersion: '8.5.15', targetVersion: 'latest' }];
+    const results = await installPackages(pkgs, 'npm', false, dir, 'test-project');
+
+    expect(results[0].success).toBe(true);
+  });
+});

--- a/src/lib/updaters/install.ts
+++ b/src/lib/updaters/install.ts
@@ -136,7 +136,19 @@ export async function installPackages(
         if (existsSync(nmPath)) {
           const installed = JSON.parse(readFileSync(nmPath, 'utf-8'));
           const isFloatingTarget = /^(latest|next|canary)$/.test(pkg.targetVersion);
-          if (installed.version === pkg.fromVersion && !isFloatingTarget) {
+          // "Version didn't change" is only a failure signal when it also
+          // isn't already the requested version. Since route.ts started
+          // passing the node_modules-read effectiveFromVersion (rather than
+          // the often-absent raw request field) for requests that omit
+          // fromVersion, fromVersion can now legitimately equal the
+          // pre-install installed version in the benign "already at the
+          // target, re-requested from a stale scan cache" case — the
+          // downgrade guard upstream deliberately lets that case through
+          // (strict `>` comparison), and a plain no-op reinstall correctly
+          // leaves the version unchanged. Without this qualifier, that
+          // benign case would report `success: false` even though the
+          // package is exactly where it should be.
+          if (installed.version === pkg.fromVersion && installed.version !== pkg.targetVersion && !isFloatingTarget) {
             verified = false;
             logger.warn('patches', 'version_unchanged', `${pkg.name} still at ${installed.version} after install`, {
               projectId,

--- a/src/lib/updaters/override.test.ts
+++ b/src/lib/updaters/override.test.ts
@@ -4,10 +4,12 @@
 // deps in place. The regression under test: applyOverrides used to write an
 // EXACT pin ("postcss": "8.5.15"), which permanently blocks routine updates
 // past a vulnerable version (29/32 projects were stuck this way on
-// GHSA-r28c-9q8g-f849). It now writes a caret floor ("^8.5.15") instead, and
-// the sibling functions (removeOverrideConflicts, cleanStaleOverrides) had to
-// stop assuming exact-pin string equality so they don't immediately delete
-// the floor applyOverrides just wrote.
+// GHSA-r28c-9q8g-f849). It now writes a `>=` floor ("postcss": ">=8.5.15")
+// instead — not a caret, because caret is inert below 1.0.0 and caps at the
+// next major even above 1.0.0 (see toFloorRange's JSDoc for the full
+// rationale) — and the sibling functions (removeOverrideConflicts,
+// cleanStaleOverrides) had to stop assuming exact-pin string equality so
+// they don't immediately delete the floor applyOverrides just wrote.
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
@@ -80,12 +82,13 @@ function writeInstalledVersion(dir: string, pkgName: string, version: string): v
 afterEach(() => {
   for (const d of dirs) rmSync(d, { recursive: true, force: true });
   dirs.length = 0;
-  execAsyncMock.mockClear();
+  execAsyncMock.mockReset();
+  execAsyncMock.mockResolvedValue({ stdout: '', stderr: '' });
 });
 
 describe('toFloorRange', () => {
-  it('turns a concrete version into a caret floor', () => {
-    expect(toFloorRange('8.5.26')).toBe('^8.5.26');
+  it('turns a concrete version into a >= floor', () => {
+    expect(toFloorRange('8.5.26')).toBe('>=8.5.26');
   });
 
   it('passes dist-tags through unchanged', () => {
@@ -94,11 +97,23 @@ describe('toFloorRange', () => {
     expect(toFloorRange('canary')).toBe('canary');
   });
 
-  it('carets a prerelease version rather than leaving it an exact pin', () => {
-    // ^1.0.0-beta.1 only matches later prereleases within 1.0.0 plus the
-    // eventual stable 1.0.0 release — narrower than a normal caret range,
-    // but that's inherent to npm semver's prerelease-tuple rule, not a bug.
-    expect(toFloorRange('1.0.0-beta.1')).toBe('^1.0.0-beta.1');
+  it('floors a 0.x version with >=, not caret (caret is inert/too-tight below 1.0.0)', () => {
+    // ^0.0.3 expands to ">=0.0.3 <0.0.4-0" — exactly one version, i.e. an
+    // exact pin wearing a caret costume. >=0.0.3 has no such ceiling.
+    expect(toFloorRange('0.0.3')).toBe('>=0.0.3');
+    // ^0.5.1 caps at <0.6.0-0, but 0.x treats the minor as the breaking
+    // axis, so that cap is still too tight for a security floor.
+    expect(toFloorRange('0.5.1')).toBe('>=0.5.1');
+  });
+
+  it('floors a normal >=1.0.0 version with >=, matching the repo convention', () => {
+    // Consistent with this repo's own hand-written overrides
+    // (esbuild: ">=0.28.1", qs, hono, ws).
+    expect(toFloorRange('8.5.26')).toBe('>=8.5.26');
+  });
+
+  it('floors a prerelease version rather than leaving it an exact pin', () => {
+    expect(toFloorRange('1.0.0-beta.1')).toBe('>=1.0.0-beta.1');
   });
 
   it('leaves an already-range value alone', () => {
@@ -115,7 +130,7 @@ describe('applyOverrides', () => {
   ];
 
   for (const { pm, overridesPath } of pkgManagers) {
-    it(`writes a caret floor (^x.y.z) for a concrete target under ${pm}`, async () => {
+    it(`writes a >= floor for a concrete target under ${pm}`, async () => {
       const dir = makeTmpDir(`hexops-apply-${pm}-`);
       writePkgJson(dir, { name: 'proj', version: '1.0.0' });
 
@@ -126,11 +141,11 @@ describe('applyOverrides', () => {
       expect(results[0].success).toBe(true);
 
       const pkgJson = readPkgJson(dir);
-      expect(overridesPath(pkgJson)?.postcss).toBe('^8.5.26');
+      expect(overridesPath(pkgJson)?.postcss).toBe('>=8.5.26');
     });
   }
 
-  it('writes a dist-tag target through unchanged (cannot caret a tag)', async () => {
+  it('writes a dist-tag target through unchanged (cannot floor a tag)', async () => {
     const dir = makeTmpDir('hexops-apply-tag-');
     writePkgJson(dir, { name: 'proj', version: '1.0.0' });
 
@@ -150,7 +165,7 @@ describe('applyOverrides', () => {
     await applyOverrides(pkgs, 'npm', dir, 'test-project');
 
     const pkgJson = readPkgJson(dir);
-    expect(pkgJson.dependencies!.postcss).toBe('^8.5.26');
+    expect(pkgJson.dependencies!.postcss).toBe('>=8.5.26');
   });
 
   it('does not warn when the resolved version satisfies the floor but is not an exact match', async () => {
@@ -166,6 +181,40 @@ describe('applyOverrides', () => {
     expect(results[0].output).not.toMatch(/resolved to .* may need lockfile reset/);
   });
 
+  it('WARNS when the installed version does not satisfy the written floor (resolved lower than target)', async () => {
+    const dir = makeTmpDir('hexops-apply-mismatch-low-');
+    writePkgJson(dir, { name: 'proj', version: '1.0.0' });
+    // The resolver picked something below the floor — a genuine mismatch
+    // that must still be caught (project issue #126: a bare >= previously
+    // failed to move the resolved version under pnpm's node-linker=hoisted,
+    // and this warning is the only thing that surfaces that).
+    writeInstalledVersion(dir, 'postcss', '8.5.20');
+
+    const pkgs: UpdatePackage[] = [{ name: 'postcss', fromVersion: '8.5.15', targetVersion: '8.5.26' }];
+    const results = await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
+
+    expect(results[0].output).toMatch(/resolved to 8\.5\.20 — may need lockfile reset/);
+  });
+
+  it('WARNS on a mismatch a bare "installed >= target" scalar check would have missed', async () => {
+    const dir = makeTmpDir('hexops-apply-mismatch-tuple-');
+    writePkgJson(dir, { name: 'proj', version: '1.0.0' });
+    // 2.0.0-alpha.1 is numerically greater than 1.0.0-beta.1 under a plain
+    // semver.gte scalar comparison, so a check of that shape would have
+    // reported success. It does NOT satisfy the >=1.0.0-beta.1 range that
+    // was actually written (npm semver's prerelease-tuple rule excludes a
+    // prerelease of a different [major,minor,patch] from an unbounded >=
+    // range whose only prerelease comparator is 1.0.0-beta.1) — and that's
+    // the real question: did the override we wrote take effect, not
+    // whether the installed version happens to look "bigger".
+    writeInstalledVersion(dir, 'weird-pkg', '2.0.0-alpha.1');
+
+    const pkgs: UpdatePackage[] = [{ name: 'weird-pkg', targetVersion: '1.0.0-beta.1' }];
+    const results = await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
+
+    expect(results[0].output).toMatch(/resolved to 2\.0\.0-alpha\.1 — may need lockfile reset/);
+  });
+
   it('preserves the project package.json indentation style', async () => {
     const dir = makeTmpDir('hexops-apply-indent-');
     // 4-space indent, deliberately different from the writer's default.
@@ -177,6 +226,52 @@ describe('applyOverrides', () => {
     const raw = readPkgJsonRaw(dir);
     expect(raw).toMatch(/^ {4}"name"/m);
   });
+
+  describe('install failure handling (the anyResolved fallback)', () => {
+    it('reports failure — does not swallow it — when install fails and nothing on disk satisfies the target', async () => {
+      const dir = makeTmpDir('hexops-apply-failhard-');
+      writePkgJson(dir, { name: 'proj', version: '1.0.0' });
+      execAsyncMock.mockRejectedValueOnce({ stdout: '', stderr: 'network error', message: 'Command failed' });
+
+      const pkgs: UpdatePackage[] = [{ name: 'postcss', fromVersion: '8.5.15', targetVersion: '8.5.26' }];
+      const results = await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
+
+      expect(results[0].success).toBe(false);
+      expect(results[0].error).toMatch(/Failed to apply override/);
+    });
+
+    it('does not let a pre-existing copy that already satisfies the target mask a failed install', async () => {
+      const dir = makeTmpDir('hexops-apply-failswallow-');
+      writePkgJson(dir, { name: 'proj', version: '1.0.0' });
+      // The tree already had a version that would satisfy the NEW target's
+      // written range before this call ever ran — installed === fromVersion,
+      // so this is stale, not evidence the failed install actually applied
+      // the override. Without the fromVersion guard, "installed >= target"
+      // would have been true here and silently reported success.
+      writeInstalledVersion(dir, 'postcss', '9.0.0');
+      execAsyncMock.mockRejectedValueOnce({ stdout: '', stderr: 'registry 503', message: 'Command failed' });
+
+      const pkgs: UpdatePackage[] = [{ name: 'postcss', fromVersion: '9.0.0', targetVersion: '8.5.26' }];
+      const results = await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
+
+      expect(results[0].success).toBe(false);
+    });
+
+    it('still recovers when install errors but the target package genuinely resolved to something new', async () => {
+      const dir = makeTmpDir('hexops-apply-failrecover-');
+      writePkgJson(dir, { name: 'proj', version: '1.0.0' });
+      // Differs from fromVersion, so this is real evidence of a completed
+      // resolution (e.g. a post-install script warning failed the overall
+      // command even though the dependency graph itself resolved fine).
+      writeInstalledVersion(dir, 'postcss', '8.5.30');
+      execAsyncMock.mockRejectedValueOnce({ stdout: '', stderr: 'postinstall script warning', message: 'Command failed' });
+
+      const pkgs: UpdatePackage[] = [{ name: 'postcss', fromVersion: '8.5.15', targetVersion: '8.5.26' }];
+      const results = await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
+
+      expect(results[0].success).toBe(true);
+    });
+  });
 });
 
 describe('removeOverrideConflicts', () => {
@@ -186,22 +281,35 @@ describe('removeOverrideConflicts', () => {
 
   it('KEEPS an override whose range already satisfies the new target (the floor-deletion regression)', () => {
     const dir = makeTmpDir('hexops-conflicts-keep-');
-    writePkgJson(dir, { name: 'proj', pnpm: { overrides: { postcss: '^8.5.23' } } });
+    writePkgJson(dir, { name: 'proj', pnpm: { overrides: { postcss: '>=8.5.23' } } });
 
     const directPkgs: UpdatePackage[] = [{ name: 'postcss', targetVersion: '8.5.26' }];
     removeOverrideConflicts(pkgJsonPathFor(dir), directPkgs, 'pnpm', 'test-project');
 
     const pkgJson = readPkgJson(dir);
-    expect(pkgJson.pnpm!.overrides!.postcss).toBe('^8.5.23');
+    expect(pkgJson.pnpm!.overrides!.postcss).toBe('>=8.5.23');
+  });
+
+  it('KEEPS a >= floor even for a target in a later major (no caret ceiling to trip over)', () => {
+    const dir = makeTmpDir('hexops-conflicts-keep-major-');
+    writePkgJson(dir, { name: 'proj', pnpm: { overrides: { postcss: '>=8.5.23' } } });
+
+    // This is exactly the case a caret floor could NOT have kept: a fix
+    // landing in a later major. >= has no ceiling, so it still satisfies.
+    const directPkgs: UpdatePackage[] = [{ name: 'postcss', targetVersion: '9.1.0' }];
+    removeOverrideConflicts(pkgJsonPathFor(dir), directPkgs, 'pnpm', 'test-project');
+
+    const pkgJson = readPkgJson(dir);
+    expect(pkgJson.pnpm!.overrides!.postcss).toBe('>=8.5.23');
   });
 
   it('REMOVES an override whose range does not satisfy the new target', () => {
     const dir = makeTmpDir('hexops-conflicts-remove-');
-    writePkgJson(dir, { name: 'proj', pnpm: { overrides: { postcss: '^8.5.23' } } });
+    writePkgJson(dir, { name: 'proj', pnpm: { overrides: { postcss: '>=8.5.23' } } });
 
-    // Major bump falls outside the caret range — the override would now
-    // conflict with (block) the direct update, so it must go.
-    const directPkgs: UpdatePackage[] = [{ name: 'postcss', targetVersion: '9.0.0' }];
+    // A lower target than the floor's base falls outside the range — the
+    // override would now conflict with (block) the direct update.
+    const directPkgs: UpdatePackage[] = [{ name: 'postcss', targetVersion: '8.5.0' }];
     removeOverrideConflicts(pkgJsonPathFor(dir), directPkgs, 'pnpm', 'test-project');
 
     const pkgJson = readPkgJson(dir);
@@ -210,7 +318,7 @@ describe('removeOverrideConflicts', () => {
 
   it('REMOVES on a floating dist-tag target regardless of the existing range', () => {
     const dir = makeTmpDir('hexops-conflicts-floating-');
-    writePkgJson(dir, { name: 'proj', overrides: { postcss: '^8.5.23' } });
+    writePkgJson(dir, { name: 'proj', overrides: { postcss: '>=8.5.23' } });
 
     const directPkgs: UpdatePackage[] = [{ name: 'postcss', targetVersion: 'latest' }];
     removeOverrideConflicts(pkgJsonPathFor(dir), directPkgs, 'npm', 'test-project');
@@ -230,6 +338,53 @@ describe('removeOverrideConflicts', () => {
     expect(pkgJson.resolutions!.postcss).toBeUndefined();
   });
 
+  it('does not throw on non-semver pinned values (workspace protocol, git URL, npm alias)', () => {
+    const dir = makeTmpDir('hexops-conflicts-nonsemver-');
+    writePkgJson(dir, {
+      name: 'proj',
+      pnpm: { overrides: { a: 'workspace:*' } },
+      overrides: { b: 'git+https://github.com/x/y.git' },
+      resolutions: { c: 'npm:alias@1.0.0' },
+    });
+
+    const pnpmPkgs: UpdatePackage[] = [{ name: 'a', targetVersion: '1.2.3' }];
+    const npmPkgs: UpdatePackage[] = [{ name: 'b', targetVersion: '1.2.3' }];
+    const yarnPkgs: UpdatePackage[] = [{ name: 'c', targetVersion: '1.2.3' }];
+
+    expect(() => removeOverrideConflicts(pkgJsonPathFor(dir), pnpmPkgs, 'pnpm', 'test-project')).not.toThrow();
+    expect(() => removeOverrideConflicts(pkgJsonPathFor(dir), npmPkgs, 'npm', 'test-project')).not.toThrow();
+    expect(() => removeOverrideConflicts(pkgJsonPathFor(dir), yarnPkgs, 'yarn', 'test-project')).not.toThrow();
+
+    // Neither side parses as semver, so it falls back to strict string
+    // comparison — all three differ from the new target, so all three are
+    // removed (the pre-floor behavior, preserved as the safe fallback).
+    const pkgJson = readPkgJson(dir);
+    expect(pkgJson.pnpm!.overrides!.a).toBeUndefined();
+    expect(pkgJson.overrides!.b).toBeUndefined();
+    expect(pkgJson.resolutions!.c).toBeUndefined();
+  });
+
+  it('always keeps a wildcard ("*") or empty-string override (harmless but previously untested)', () => {
+    const dir = makeTmpDir('hexops-conflicts-wildcard-');
+    writePkgJson(dir, { name: 'proj', pnpm: { overrides: { a: '*', b: '' } } });
+
+    const directPkgs: UpdatePackage[] = [
+      { name: 'a', targetVersion: '8.5.26' },
+      { name: 'b', targetVersion: '9.0.0' },
+    ];
+    removeOverrideConflicts(pkgJsonPathFor(dir), directPkgs, 'pnpm', 'test-project');
+
+    // semver parses both "*" and "" as an "any version" range, so any
+    // concrete target always satisfies them — never a conflict, never
+    // removed. Behavior change from the old exact-string-equality check
+    // (which would have removed both, since neither equals the target
+    // string), but a harmless one: a wildcard/empty override was never a
+    // meaningful pin to begin with.
+    const pkgJson = readPkgJson(dir);
+    expect(pkgJson.pnpm!.overrides!.a).toBe('*');
+    expect(pkgJson.pnpm!.overrides!.b).toBe('');
+  });
+
   it('preserves package.json indentation when it rewrites the file', () => {
     const dir = makeTmpDir('hexops-conflicts-indent-');
     writePkgJson(dir, { name: 'proj', overrides: { postcss: '8.5.15' } }, 4);
@@ -245,13 +400,13 @@ describe('removeOverrideConflicts', () => {
 describe('cleanStaleOverrides', () => {
   it('leaves a range-valued override untouched even when installed resolves higher', () => {
     const dir = makeTmpDir('hexops-stale-range-');
-    writePkgJson(dir, { name: 'proj', pnpm: { overrides: { postcss: '^8.5.23' } } });
+    writePkgJson(dir, { name: 'proj', pnpm: { overrides: { postcss: '>=8.5.23' } } });
     writeInstalledVersion(dir, 'postcss', '8.5.30');
 
     cleanStaleOverrides(dir, 'pnpm', 'test-project');
 
     const pkgJson = readPkgJson(dir);
-    expect(pkgJson.pnpm!.overrides!.postcss).toBe('^8.5.23');
+    expect(pkgJson.pnpm!.overrides!.postcss).toBe('>=8.5.23');
   });
 
   it('still removes a genuinely stale exact pin', () => {

--- a/src/lib/updaters/override.test.ts
+++ b/src/lib/updaters/override.test.ts
@@ -44,8 +44,19 @@ vi.mock('@/lib/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
-import { applyOverrides, removeOverrideConflicts, cleanStaleOverrides, toFloorRange } from './override';
+import { applyOverrides, removeOverrideConflicts, cleanStaleOverrides, toFloorRange, findAllInstalledVersions, pickPrimaryVersion, pickLowestVersion } from './override';
 import { logger } from '@/lib/logger';
+
+// Mirrors route.ts's downgrade-guard arithmetic exactly (see
+// src/app/api/projects/[id]/update/route.ts, the `isDowngrade` computation
+// fed by `effectiveFromVersion`) — kept in lockstep on purpose so the B1
+// pinning test below proves the guard's actual behavior, not a paraphrase
+// of it.
+function isDowngrade(fromVersion: string, targetVersion: string): boolean {
+  const fv = fromVersion.replace(/^[\^~]/, '').split('.').map(n => parseInt(n, 10) || 0);
+  const tv = targetVersion.replace(/^[\^~]/, '').split('.').map(n => parseInt(n, 10) || 0);
+  return fv[0] > tv[0] || (fv[0] === tv[0] && fv[1] > tv[1]) || (fv[0] === tv[0] && fv[1] === tv[1] && (fv[2] ?? 0) > (tv[2] ?? 0));
+}
 
 const dirs: string[] = [];
 function makeTmpDir(prefix: string): string {
@@ -312,6 +323,55 @@ describe('applyOverrides', () => {
       expect(results[0].resolvedVersion).toBe('8.4.31');
     });
 
+    it('B1 regression: a route-level downgrade guard fed the LOWEST copy does not refuse an update a HIGHEST-copy guard would wrongly refuse', async () => {
+      // Reproduces the exact scenario a round-4 fix (F4: route.ts reading
+      // effectiveFromVersion via the isolated-linker-aware lookup) broke:
+      // no root copy, a vulnerable copy and a clean copy coexisting in the
+      // .pnpm store, target sitting between them. route.ts's downgrade
+      // guard must be fed the LOWEST copy (pickLowestVersion) — feeding it
+      // the highest (what pickPrimaryVersion, or the old root-preferring
+      // logic, would return) makes the guard refuse the whole update as
+      // "already past this fix" while the vulnerable copy survives
+      // untouched. That's worse than the pre-round-3 behavior, where a
+      // root-only read returned '' and the guard was simply inert.
+      const dir = makeTmpDir('hexops-b1-downgrade-guard-');
+      writePkgJson(dir, { name: 'proj', version: '1.0.0', dependencies: { next: '16.3.0' } });
+      writePnpmStoreVersion(dir, 'postcss', '8.4.31'); // vulnerable
+      writePnpmStoreVersion(dir, 'postcss', '8.5.30', '_react@19.2.7'); // clean
+
+      const target = '8.5.26';
+      const { root, all } = findAllInstalledVersions(dir, 'postcss');
+      expect(root).toBeUndefined(); // no root copy — the isolated-linker case
+
+      // The regression: pickPrimaryVersion (root-or-highest) picks the
+      // CLEAN copy, and feeding that into the guard falsely refuses.
+      const wronglyPicked = pickPrimaryVersion(root, all);
+      expect(wronglyPicked).toBe('8.5.30');
+      expect(isDowngrade(wronglyPicked!, target)).toBe(true); // <- the bug: would refuse
+
+      // The fix: pickLowestVersion (worst case across every copy) picks the
+      // VULNERABLE copy, and feeding that into the same guard does not
+      // refuse — there's still a copy below target, so the update must be
+      // allowed to proceed.
+      const correctlyPicked = pickLowestVersion(all);
+      expect(correctlyPicked).toBe('8.4.31');
+      expect(isDowngrade(correctlyPicked!, target)).toBe(false); // <- not refused
+
+      // End-to-end: with the guard correctly not refusing, the request
+      // reaches applyOverrides, and the override IS written — the
+      // regression's whole point was that it never got this far.
+      const pkgs: UpdatePackage[] = [{ name: 'postcss', fromVersion: correctlyPicked, targetVersion: target }];
+      const results = await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
+
+      expect(results[0].success).toBe(true);
+      const pkgJson = readPkgJson(dir);
+      expect(pkgJson.pnpm!.overrides!.postcss).toBe('>=8.5.26');
+      // applyOverrides' own (separate, more thorough) verification still
+      // correctly flags the vulnerable copy still sitting in the store —
+      // the route-level guard's job was only to not block the attempt.
+      expect(results[0].output).toMatch(/resolved to 8\.4\.31 \(does not satisfy >=8\.5\.26\) — may need lockfile reset/);
+    });
+
     it('does not silently discard violations when one of the copies has an unparseable version field', async () => {
       const dir = makeTmpDir('hexops-apply-pnpmstore-garbage-');
       writePkgJson(dir, { name: 'proj', version: '1.0.0' });
@@ -337,6 +397,43 @@ describe('applyOverrides', () => {
         expect.any(String),
         expect.objectContaining({ meta: expect.objectContaining({ package: 'weird' }) }),
       );
+    });
+
+    it('B2 regression: a loose-parseable/strict-invalid version does not silently swallow a violation', async () => {
+      // `semver.valid(v, {loose:true})` accepts "1.02.3" (a leading zero in
+      // the minor segment), but `semver.compare`/`semver.rcompare` called
+      // bare as a .sort() comparator run WITHOUT the loose flag and throw on
+      // it. Two copies is what triggers the throw (a lone element never
+      // invokes the sort comparator) — verified directly against the real
+      // semver package before writing this test:
+      //   semver.valid('1.02.3', {loose:true})        -> '1.2.3' (accepted)
+      //   ['1.02.3','1.5.0'].sort(semver.compare)      -> throws
+      //   ['1.02.3','1.5.0'].sort((a,b)=>semver.compare(a,b,{loose:true})) -> fine
+      // Both copies violate the target here, so this pins the structural
+      // fix too: the warning must fire even if version SELECTION afterward
+      // throws, because the warning is now assigned before selection runs.
+      const dir = makeTmpDir('hexops-b2-loose-strict-');
+      writePkgJson(dir, { name: 'proj', version: '1.0.0' });
+      writePnpmStoreVersion(dir, 'loosepkg', '1.02.3');
+      writePnpmStoreVersion(dir, 'loosepkg', '1.5.0', '_extra');
+
+      const pkgs: UpdatePackage[] = [{ name: 'loosepkg', targetVersion: '2.0.0' }];
+      const results = await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
+
+      // No silent success: the mismatch warning must fire for real, not get
+      // swallowed by a version-selection throw.
+      expect(results[0].success).toBe(true); // a floor violation still isn't a hard failure
+      expect(results[0].output).toMatch(/may need lockfile reset/);
+      expect(logger.warn).toHaveBeenCalledWith(
+        'patches',
+        'override_version_mismatch',
+        expect.any(String),
+        expect.objectContaining({ meta: expect.objectContaining({ package: 'loosepkg' }) }),
+      );
+      // With the loose flag now passed to the sort comparator too, version
+      // selection succeeds rather than throwing, so the structured field is
+      // populated with the worse of the two violators.
+      expect(results[0].resolvedVersion).toBe('1.02.3');
     });
 
     it('does not throw when a lone unparseable version field is the ONLY copy found', async () => {

--- a/src/lib/updaters/override.test.ts
+++ b/src/lib/updaters/override.test.ts
@@ -1,0 +1,293 @@
+// src/lib/updaters/override.test.ts
+//
+// override.ts writes the overrides that hold ~35 fleet projects' transitive
+// deps in place. The regression under test: applyOverrides used to write an
+// EXACT pin ("postcss": "8.5.15"), which permanently blocks routine updates
+// past a vulnerable version (29/32 projects were stuck this way on
+// GHSA-r28c-9q8g-f849). It now writes a caret floor ("^8.5.15") instead, and
+// the sibling functions (removeOverrideConflicts, cleanStaleOverrides) had to
+// stop assuming exact-pin string equality so they don't immediately delete
+// the floor applyOverrides just wrote.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { UpdatePackage } from './common';
+
+// applyOverrides shells out to the real package manager (`pnpm install`, etc.)
+// after writing package.json. Actually running that in a unit test would be
+// slow, flaky, and network-dependent, so execAsync is stubbed — everything
+// else from './common' (NPM_INSTALL_TIMEOUT, verifyAuditClear) stays real.
+// vi.mock factories are hoisted above imports, so the stub is created inline
+// rather than referencing an outer const.
+const { execAsyncMock } = vi.hoisted(() => ({
+  execAsyncMock: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+}));
+vi.mock('./common', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./common')>();
+  return { ...actual, execAsync: execAsyncMock };
+});
+
+// addPatchHistoryEntry/logger.* write real files under `.hexops/` in
+// process.cwd(). Stub them so the test suite doesn't leave that litter in
+// the repo working tree; generatePatchId and everything else in
+// patch-storage stays real since patch-scanner's getUpdateType chain
+// depends on other named exports from the same module existing.
+vi.mock('@/lib/patch-storage', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/patch-storage')>();
+  return { ...actual, addPatchHistoryEntry: vi.fn() };
+});
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { applyOverrides, removeOverrideConflicts, cleanStaleOverrides, toFloorRange } from './override';
+
+const dirs: string[] = [];
+function makeTmpDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  dirs.push(dir);
+  return dir;
+}
+
+function writePkgJson(dir: string, content: unknown, indent = 2): void {
+  writeFileSync(join(dir, 'package.json'), `${JSON.stringify(content, null, indent)}\n`, 'utf-8');
+}
+
+function readPkgJsonRaw(dir: string): string {
+  return readFileSync(join(dir, 'package.json'), 'utf-8');
+}
+
+interface PkgJsonLike {
+  pnpm?: { overrides?: Record<string, string> };
+  overrides?: Record<string, string>;
+  resolutions?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+function readPkgJson(dir: string): PkgJsonLike {
+  return JSON.parse(readPkgJsonRaw(dir));
+}
+
+function writeInstalledVersion(dir: string, pkgName: string, version: string): void {
+  const pkgDir = join(dir, 'node_modules', pkgName);
+  mkdirSync(pkgDir, { recursive: true });
+  writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({ name: pkgName, version }), 'utf-8');
+}
+
+afterEach(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+  dirs.length = 0;
+  execAsyncMock.mockClear();
+});
+
+describe('toFloorRange', () => {
+  it('turns a concrete version into a caret floor', () => {
+    expect(toFloorRange('8.5.26')).toBe('^8.5.26');
+  });
+
+  it('passes dist-tags through unchanged', () => {
+    expect(toFloorRange('latest')).toBe('latest');
+    expect(toFloorRange('next')).toBe('next');
+    expect(toFloorRange('canary')).toBe('canary');
+  });
+
+  it('carets a prerelease version rather than leaving it an exact pin', () => {
+    // ^1.0.0-beta.1 only matches later prereleases within 1.0.0 plus the
+    // eventual stable 1.0.0 release — narrower than a normal caret range,
+    // but that's inherent to npm semver's prerelease-tuple rule, not a bug.
+    expect(toFloorRange('1.0.0-beta.1')).toBe('^1.0.0-beta.1');
+  });
+
+  it('leaves an already-range value alone', () => {
+    expect(toFloorRange('^8.5.23')).toBe('^8.5.23');
+    expect(toFloorRange('>=0.28.1')).toBe('>=0.28.1');
+  });
+});
+
+describe('applyOverrides', () => {
+  const pkgManagers: Array<{ pm: string; overridesPath: (pkgJson: PkgJsonLike) => Record<string, string> | undefined }> = [
+    { pm: 'pnpm', overridesPath: (p) => p.pnpm?.overrides },
+    { pm: 'npm', overridesPath: (p) => p.overrides },
+    { pm: 'yarn', overridesPath: (p) => p.resolutions },
+  ];
+
+  for (const { pm, overridesPath } of pkgManagers) {
+    it(`writes a caret floor (^x.y.z) for a concrete target under ${pm}`, async () => {
+      const dir = makeTmpDir(`hexops-apply-${pm}-`);
+      writePkgJson(dir, { name: 'proj', version: '1.0.0' });
+
+      const pkgs: UpdatePackage[] = [{ name: 'postcss', fromVersion: '8.5.15', targetVersion: '8.5.26' }];
+      const results = await applyOverrides(pkgs, pm, dir, 'test-project');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].success).toBe(true);
+
+      const pkgJson = readPkgJson(dir);
+      expect(overridesPath(pkgJson)?.postcss).toBe('^8.5.26');
+    });
+  }
+
+  it('writes a dist-tag target through unchanged (cannot caret a tag)', async () => {
+    const dir = makeTmpDir('hexops-apply-tag-');
+    writePkgJson(dir, { name: 'proj', version: '1.0.0' });
+
+    const pkgs: UpdatePackage[] = [{ name: 'some-pkg', targetVersion: 'latest' }];
+    const results = await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
+
+    expect(results[0].success).toBe(true);
+    const pkgJson = readPkgJson(dir);
+    expect(pkgJson.pnpm!.overrides!['some-pkg']).toBe('latest');
+  });
+
+  it('floors the direct-dependency specifier too, not just the override, under npm', async () => {
+    const dir = makeTmpDir('hexops-apply-npm-direct-');
+    writePkgJson(dir, { name: 'proj', version: '1.0.0', dependencies: { postcss: '8.4.31' } });
+
+    const pkgs: UpdatePackage[] = [{ name: 'postcss', fromVersion: '8.4.31', targetVersion: '8.5.26' }];
+    await applyOverrides(pkgs, 'npm', dir, 'test-project');
+
+    const pkgJson = readPkgJson(dir);
+    expect(pkgJson.dependencies!.postcss).toBe('^8.5.26');
+  });
+
+  it('does not warn when the resolved version satisfies the floor but is not an exact match', async () => {
+    const dir = makeTmpDir('hexops-apply-satisfy-');
+    writePkgJson(dir, { name: 'proj', version: '1.0.0' });
+    // Simulate the install having resolved to a newer patch than the floor's base —
+    // this is success, not a mismatch, now that the override is a floor.
+    writeInstalledVersion(dir, 'postcss', '8.5.30');
+
+    const pkgs: UpdatePackage[] = [{ name: 'postcss', fromVersion: '8.5.15', targetVersion: '8.5.26' }];
+    const results = await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
+
+    expect(results[0].output).not.toMatch(/resolved to .* may need lockfile reset/);
+  });
+
+  it('preserves the project package.json indentation style', async () => {
+    const dir = makeTmpDir('hexops-apply-indent-');
+    // 4-space indent, deliberately different from the writer's default.
+    writePkgJson(dir, { name: 'proj', version: '1.0.0' }, 4);
+
+    const pkgs: UpdatePackage[] = [{ name: 'postcss', targetVersion: '8.5.26' }];
+    await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
+
+    const raw = readPkgJsonRaw(dir);
+    expect(raw).toMatch(/^ {4}"name"/m);
+  });
+});
+
+describe('removeOverrideConflicts', () => {
+  function pkgJsonPathFor(dir: string): string {
+    return join(dir, 'package.json');
+  }
+
+  it('KEEPS an override whose range already satisfies the new target (the floor-deletion regression)', () => {
+    const dir = makeTmpDir('hexops-conflicts-keep-');
+    writePkgJson(dir, { name: 'proj', pnpm: { overrides: { postcss: '^8.5.23' } } });
+
+    const directPkgs: UpdatePackage[] = [{ name: 'postcss', targetVersion: '8.5.26' }];
+    removeOverrideConflicts(pkgJsonPathFor(dir), directPkgs, 'pnpm', 'test-project');
+
+    const pkgJson = readPkgJson(dir);
+    expect(pkgJson.pnpm!.overrides!.postcss).toBe('^8.5.23');
+  });
+
+  it('REMOVES an override whose range does not satisfy the new target', () => {
+    const dir = makeTmpDir('hexops-conflicts-remove-');
+    writePkgJson(dir, { name: 'proj', pnpm: { overrides: { postcss: '^8.5.23' } } });
+
+    // Major bump falls outside the caret range — the override would now
+    // conflict with (block) the direct update, so it must go.
+    const directPkgs: UpdatePackage[] = [{ name: 'postcss', targetVersion: '9.0.0' }];
+    removeOverrideConflicts(pkgJsonPathFor(dir), directPkgs, 'pnpm', 'test-project');
+
+    const pkgJson = readPkgJson(dir);
+    expect(pkgJson.pnpm!.overrides!.postcss).toBeUndefined();
+  });
+
+  it('REMOVES on a floating dist-tag target regardless of the existing range', () => {
+    const dir = makeTmpDir('hexops-conflicts-floating-');
+    writePkgJson(dir, { name: 'proj', overrides: { postcss: '^8.5.23' } });
+
+    const directPkgs: UpdatePackage[] = [{ name: 'postcss', targetVersion: 'latest' }];
+    removeOverrideConflicts(pkgJsonPathFor(dir), directPkgs, 'npm', 'test-project');
+
+    const pkgJson = readPkgJson(dir);
+    expect(pkgJson.overrides!.postcss).toBeUndefined();
+  });
+
+  it('still removes a stale EXACT pin that differs from the new target (pre-floor behavior)', () => {
+    const dir = makeTmpDir('hexops-conflicts-exact-');
+    writePkgJson(dir, { name: 'proj', resolutions: { postcss: '8.5.15' } });
+
+    const directPkgs: UpdatePackage[] = [{ name: 'postcss', targetVersion: '8.5.26' }];
+    removeOverrideConflicts(pkgJsonPathFor(dir), directPkgs, 'yarn', 'test-project');
+
+    const pkgJson = readPkgJson(dir);
+    expect(pkgJson.resolutions!.postcss).toBeUndefined();
+  });
+
+  it('preserves package.json indentation when it rewrites the file', () => {
+    const dir = makeTmpDir('hexops-conflicts-indent-');
+    writePkgJson(dir, { name: 'proj', overrides: { postcss: '8.5.15' } }, 4);
+
+    const directPkgs: UpdatePackage[] = [{ name: 'postcss', targetVersion: '8.5.26' }];
+    removeOverrideConflicts(pkgJsonPathFor(dir), directPkgs, 'npm', 'test-project');
+
+    const raw = readPkgJsonRaw(dir);
+    expect(raw).toMatch(/^ {4}"name"/m);
+  });
+});
+
+describe('cleanStaleOverrides', () => {
+  it('leaves a range-valued override untouched even when installed resolves higher', () => {
+    const dir = makeTmpDir('hexops-stale-range-');
+    writePkgJson(dir, { name: 'proj', pnpm: { overrides: { postcss: '^8.5.23' } } });
+    writeInstalledVersion(dir, 'postcss', '8.5.30');
+
+    cleanStaleOverrides(dir, 'pnpm', 'test-project');
+
+    const pkgJson = readPkgJson(dir);
+    expect(pkgJson.pnpm!.overrides!.postcss).toBe('^8.5.23');
+  });
+
+  it('still removes a genuinely stale exact pin', () => {
+    const dir = makeTmpDir('hexops-stale-exact-');
+    writePkgJson(dir, { name: 'proj', pnpm: { overrides: { postcss: '8.5.15' } } });
+    writeInstalledVersion(dir, 'postcss', '8.5.30');
+
+    cleanStaleOverrides(dir, 'pnpm', 'test-project');
+
+    const pkgJson = readPkgJson(dir);
+    expect(pkgJson.pnpm!.overrides!.postcss).toBeUndefined();
+  });
+
+  it('uses real semver comparison, not naive string/parseInt splitting (prerelease case)', () => {
+    const dir = makeTmpDir('hexops-stale-prerelease-');
+    // 1.0.0-beta.1 must NOT be treated as "newer" than 1.0.0 — a naive
+    // parseInt split on major.minor.patch would compare 1.0.0 vs 1.0.0 as
+    // equal and miss the prerelease tag entirely.
+    writePkgJson(dir, { name: 'proj', pnpm: { overrides: { foo: '1.0.0' } } });
+    writeInstalledVersion(dir, 'foo', '1.0.0-beta.1');
+
+    cleanStaleOverrides(dir, 'pnpm', 'test-project');
+
+    const pkgJson = readPkgJson(dir);
+    // 1.0.0-beta.1 is NOT newer than 1.0.0, so the pin must survive.
+    expect(pkgJson.pnpm!.overrides!.foo).toBe('1.0.0');
+  });
+
+  it('preserves package.json indentation when it rewrites the file', () => {
+    const dir = makeTmpDir('hexops-stale-indent-');
+    writePkgJson(dir, { name: 'proj', pnpm: { overrides: { postcss: '8.5.15' } } }, 4);
+    writeInstalledVersion(dir, 'postcss', '8.5.30');
+
+    cleanStaleOverrides(dir, 'pnpm', 'test-project');
+
+    const raw = readPkgJsonRaw(dir);
+    expect(raw).toMatch(/^ {4}"name"/m);
+  });
+});

--- a/src/lib/updaters/override.test.ts
+++ b/src/lib/updaters/override.test.ts
@@ -45,6 +45,7 @@ vi.mock('@/lib/logger', () => ({
 }));
 
 import { applyOverrides, removeOverrideConflicts, cleanStaleOverrides, toFloorRange } from './override';
+import { logger } from '@/lib/logger';
 
 const dirs: string[] = [];
 function makeTmpDir(prefix: string): string {
@@ -79,11 +80,28 @@ function writeInstalledVersion(dir: string, pkgName: string, version: string): v
   writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({ name: pkgName, version }), 'utf-8');
 }
 
+// Simulates pnpm's default `node-linker=isolated` virtual store layout:
+// node_modules/.pnpm/<name>@<version>[_peerSuffix]/node_modules/<name>/package.json,
+// with scoped names' "/" replaced by "+" in the store directory name — the
+// exact convention confirmed against this repo's own `pnpm list --json`
+// output (e.g. `@vitest/ui` stores as `.pnpm/@vitest+ui@4.1.9_.../...`).
+// `peerSuffix` lets a test create two distinct store directories for the
+// same package+version-prefix (i.e. two different peer-dep resolutions),
+// or more commonly here, two different versions entirely.
+function writePnpmStoreVersion(dir: string, pkgName: string, version: string, peerSuffix = ''): void {
+  const storeDirName = `${pkgName.replace('/', '+')}@${version}${peerSuffix}`;
+  const pkgDir = join(dir, 'node_modules', '.pnpm', storeDirName, 'node_modules', pkgName);
+  mkdirSync(pkgDir, { recursive: true });
+  writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({ name: pkgName, version }), 'utf-8');
+}
+
 afterEach(() => {
   for (const d of dirs) rmSync(d, { recursive: true, force: true });
   dirs.length = 0;
   execAsyncMock.mockReset();
   execAsyncMock.mockResolvedValue({ stdout: '', stderr: '' });
+  vi.mocked(logger.warn).mockClear();
+  vi.mocked(logger.info).mockClear();
 });
 
 describe('toFloorRange', () => {
@@ -168,7 +186,7 @@ describe('applyOverrides', () => {
     expect(pkgJson.dependencies!.postcss).toBe('>=8.5.26');
   });
 
-  it('does not warn when the resolved version satisfies the floor but is not an exact match', async () => {
+  it('does not warn when the resolved version satisfies the floor but is not an exact match, and reports the resolved version', async () => {
     const dir = makeTmpDir('hexops-apply-satisfy-');
     writePkgJson(dir, { name: 'proj', version: '1.0.0' });
     // Simulate the install having resolved to a newer patch than the floor's base —
@@ -178,7 +196,12 @@ describe('applyOverrides', () => {
     const pkgs: UpdatePackage[] = [{ name: 'postcss', fromVersion: '8.5.15', targetVersion: '8.5.26' }];
     const results = await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
 
-    expect(results[0].output).not.toMatch(/resolved to .* may need lockfile reset/);
+    expect(results[0].output).not.toMatch(/may need lockfile reset/);
+    // The written floor stays visible (">=8.5.26") alongside what actually
+    // resolved (8.5.30) — the point is "requested X, resolved Y", not one
+    // or the other.
+    expect(results[0].output).toMatch(/postcss@>=8\.5\.26, resolved 8\.5\.30/);
+    expect(results[0].resolvedVersion).toBe('8.5.30');
   });
 
   it('WARNS when the installed version does not satisfy the written floor (resolved lower than target)', async () => {
@@ -193,7 +216,7 @@ describe('applyOverrides', () => {
     const pkgs: UpdatePackage[] = [{ name: 'postcss', fromVersion: '8.5.15', targetVersion: '8.5.26' }];
     const results = await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
 
-    expect(results[0].output).toMatch(/resolved to 8\.5\.20 — may need lockfile reset/);
+    expect(results[0].output).toMatch(/resolved to 8\.5\.20 \(does not satisfy >=8\.5\.26\) — may need lockfile reset/);
   });
 
   it('WARNS on a mismatch a bare "installed >= target" scalar check would have missed', async () => {
@@ -212,7 +235,138 @@ describe('applyOverrides', () => {
     const pkgs: UpdatePackage[] = [{ name: 'weird-pkg', targetVersion: '1.0.0-beta.1' }];
     const results = await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
 
-    expect(results[0].output).toMatch(/resolved to 2\.0\.0-alpha\.1 — may need lockfile reset/);
+    expect(results[0].output).toMatch(/resolved to 2\.0\.0-alpha\.1 \(does not satisfy >=1\.0\.0-beta\.1\) — may need lockfile reset/);
+  });
+
+  it('logs a distinct warning — not a failure — when the resolved version is a newer major than targeted', async () => {
+    const dir = makeTmpDir('hexops-apply-majorjump-');
+    writePkgJson(dir, { name: 'proj', version: '1.0.0' });
+    // Satisfies the >=8.5.26 floor (no ceiling, by owner decision), but
+    // lands in a major well beyond the one that was targeted.
+    writeInstalledVersion(dir, 'postcss', '10.1.0');
+
+    const pkgs: UpdatePackage[] = [{ name: 'postcss', fromVersion: '8.5.15', targetVersion: '8.5.26' }];
+    const results = await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
+
+    expect(results[0].success).toBe(true);
+    expect(results[0].resolvedVersion).toBe('10.1.0');
+    expect(results[0].output).not.toMatch(/may need lockfile reset/); // satisfies the floor — not a mismatch
+    expect(logger.warn).toHaveBeenCalledWith(
+      'patches',
+      'override_major_jump',
+      expect.any(String),
+      expect.objectContaining({
+        meta: expect.objectContaining({ package: 'postcss', resolvedVersion: '10.1.0', targetMajor: 8, resolvedMajor: 10 }),
+      }),
+    );
+  });
+
+  describe('resolved-version lookup (isolated pnpm node-linker)', () => {
+    it('finds the resolved version via the .pnpm store when there is no root node_modules entry', async () => {
+      const dir = makeTmpDir('hexops-apply-pnpmstore-');
+      writePkgJson(dir, { name: 'proj', version: '1.0.0' });
+      // No root node_modules/postcss at all — simulates pnpm's default
+      // isolated linker, where a purely-transitive package lives only in
+      // the .pnpm store. This is the concretely-identified blind spot: a
+      // root-only existsSync check silently no-ops on this layout.
+      writePnpmStoreVersion(dir, 'postcss', '8.5.30');
+
+      const pkgs: UpdatePackage[] = [{ name: 'postcss', fromVersion: '8.5.15', targetVersion: '8.5.26' }];
+      const results = await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
+
+      expect(results[0].success).toBe(true);
+      expect(results[0].resolvedVersion).toBe('8.5.30');
+      expect(results[0].output).not.toMatch(/may need lockfile reset/);
+    });
+
+    it('resolves a scoped package from the .pnpm store using the "/" -> "+" name encoding', async () => {
+      const dir = makeTmpDir('hexops-apply-pnpmstore-scoped-');
+      writePkgJson(dir, { name: 'proj', version: '1.0.0' });
+      writePnpmStoreVersion(dir, '@scope/pkg', '2.1.0');
+
+      const pkgs: UpdatePackage[] = [{ name: '@scope/pkg', targetVersion: '2.0.0' }];
+      const results = await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
+
+      expect(results[0].resolvedVersion).toBe('2.1.0');
+    });
+
+    it('flags a mismatch when ANY copy in the .pnpm store falls below the floor, even if others satisfy it', async () => {
+      const dir = makeTmpDir('hexops-apply-pnpmstore-multi-');
+      writePkgJson(dir, { name: 'proj', version: '1.0.0' });
+      // Two distinct copies coexist in the store — one satisfying, one
+      // still vulnerable. A check that stopped at the first hit (or only
+      // ever looked at root) would miss this — exactly the "top-level fix,
+      // vulnerable nested copy survives" false-clear class this project
+      // already tracks as issue #80.
+      writePnpmStoreVersion(dir, 'postcss', '8.5.30');
+      writePnpmStoreVersion(dir, 'postcss', '8.4.31', '_react@19.2.7');
+
+      const pkgs: UpdatePackage[] = [{ name: 'postcss', fromVersion: '8.5.15', targetVersion: '8.5.26' }];
+      const results = await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
+
+      expect(results[0].success).toBe(true); // a floor violation still isn't "success: false" territory
+      expect(results[0].output).toMatch(/resolved to 8\.4\.31 \(does not satisfy >=8\.5\.26\) — may need lockfile reset/);
+    });
+
+    it('falls back to `pnpm list --json` when the filesystem probe (root + .pnpm store) finds nothing', async () => {
+      const dir = makeTmpDir('hexops-apply-clifallback-');
+      writePkgJson(dir, { name: 'proj', version: '1.0.0' });
+      // No root copy, no .pnpm store directory at all — filesystem probe is
+      // fully empty. This simulates a store location or workspace layout
+      // the filesystem probe doesn't recognize.
+      execAsyncMock.mockImplementation(async (cmd: unknown) => {
+        if (typeof cmd === 'string' && cmd.includes('pnpm list')) {
+          return {
+            stdout: JSON.stringify([{
+              name: 'proj',
+              dependencies: { next: { version: '16.3.0', dependencies: { postcss: { version: '8.5.30' } } } },
+            }]),
+            stderr: '',
+          };
+        }
+        return { stdout: '', stderr: '' }; // the install command itself
+      });
+
+      const pkgs: UpdatePackage[] = [{ name: 'postcss', fromVersion: '8.5.15', targetVersion: '8.5.26' }];
+      const results = await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
+
+      expect(results[0].success).toBe(true);
+      expect(results[0].resolvedVersion).toBe('8.5.30');
+    });
+
+    it('reports "could not verify" — not silent success — when no method can find the package at all', async () => {
+      const dir = makeTmpDir('hexops-apply-inconclusive-');
+      writePkgJson(dir, { name: 'proj', version: '1.0.0' });
+      // Filesystem probe empty AND the pnpm list fallback comes back empty
+      // too (e.g. `pnpm list <pkg>` finds no matching dependency path).
+      execAsyncMock.mockResolvedValue({ stdout: '[]', stderr: '' });
+
+      const pkgs: UpdatePackage[] = [{ name: 'postcss', fromVersion: '8.5.15', targetVersion: '8.5.26' }];
+      const results = await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
+
+      expect(results[0].success).toBe(true); // inconclusive is not treated as a hard failure
+      expect(results[0].resolvedVersion).toBeUndefined();
+      expect(results[0].output).toMatch(/could not verify postcss's resolved version/);
+      expect(logger.warn).toHaveBeenCalledWith(
+        'patches',
+        'override_verify_inconclusive',
+        expect.any(String),
+        expect.objectContaining({ meta: expect.objectContaining({ package: 'postcss' }) }),
+      );
+    });
+
+    it('the anyResolved install-failure fallback also finds a .pnpm-store-only copy (not just root)', async () => {
+      const dir = makeTmpDir('hexops-apply-failrecover-pnpmstore-');
+      writePkgJson(dir, { name: 'proj', version: '1.0.0' });
+      // No root copy — only the isolated-linker .pnpm store has it.
+      writePnpmStoreVersion(dir, 'postcss', '8.5.30');
+      execAsyncMock.mockRejectedValueOnce({ stdout: '', stderr: 'postinstall script warning', message: 'Command failed' });
+
+      const pkgs: UpdatePackage[] = [{ name: 'postcss', fromVersion: '8.5.15', targetVersion: '8.5.26' }];
+      const results = await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
+
+      expect(results[0].success).toBe(true);
+    });
   });
 
   it('preserves the project package.json indentation style', async () => {

--- a/src/lib/updaters/override.test.ts
+++ b/src/lib/updaters/override.test.ts
@@ -306,6 +306,75 @@ describe('applyOverrides', () => {
 
       expect(results[0].success).toBe(true); // a floor violation still isn't "success: false" territory
       expect(results[0].output).toMatch(/resolved to 8\.4\.31 \(does not satisfy >=8\.5\.26\) — may need lockfile reset/);
+      // The structured field must not read as clean when a violating copy
+      // exists — it reports the worst (most vulnerable) offender, not
+      // whichever copy happens to be "root" or highest.
+      expect(results[0].resolvedVersion).toBe('8.4.31');
+    });
+
+    it('does not silently discard violations when one of the copies has an unparseable version field', async () => {
+      const dir = makeTmpDir('hexops-apply-pnpmstore-garbage-');
+      writePkgJson(dir, { name: 'proj', version: '1.0.0' });
+      // A non-semver `version` field (malformed package.json, a vendor
+      // fork, etc.) used to make `probe.versions.sort(semver.rcompare)`
+      // THROW once a second, differently-shaped copy existed — and that
+      // throw was swallowed by this function's outer catch-all, discarding
+      // the fact that NEITHER copy satisfies the floor along with it:
+      // silent `success: true`, no warning, nothing. That's strictly worse
+      // than the pre-fix existsSync no-op, because the violating versions
+      // were in hand and got thrown away instead of reported.
+      writePnpmStoreVersion(dir, 'weird', '1.0');
+      writePnpmStoreVersion(dir, 'weird', '1.5.0', '_extra');
+
+      const pkgs: UpdatePackage[] = [{ name: 'weird', targetVersion: '2.0.0' }];
+      const results = await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
+
+      expect(results[0].success).toBe(true); // still not a hard failure — see other tests for that distinction
+      expect(results[0].output).toMatch(/may need lockfile reset/);
+      expect(logger.warn).toHaveBeenCalledWith(
+        'patches',
+        'override_version_mismatch',
+        expect.any(String),
+        expect.objectContaining({ meta: expect.objectContaining({ package: 'weird' }) }),
+      );
+    });
+
+    it('does not throw when a lone unparseable version field is the ONLY copy found', async () => {
+      // Array.prototype.sort never invokes its comparator for a
+      // single-element array, so a lone garbage version was already safe
+      // before this fix — this test pins that it stays safe after the
+      // rewrite too (parseable-filtering must not turn "one weird copy"
+      // into "inconclusive" or throw).
+      const dir = makeTmpDir('hexops-apply-pnpmstore-garbage-single-');
+      writePkgJson(dir, { name: 'proj', version: '1.0.0' });
+      writePnpmStoreVersion(dir, 'weird', 'not-a-version');
+
+      const pkgs: UpdatePackage[] = [{ name: 'weird', targetVersion: '2.0.0' }];
+      const results = await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
+
+      expect(results[0].success).toBe(true);
+      expect(results[0].output).toMatch(/may need lockfile reset/);
+    });
+
+    it('does not match a package name that is merely a prefix of another (postcss vs postcss-import)', async () => {
+      const dir = makeTmpDir('hexops-apply-prefix-collision-');
+      writePkgJson(dir, { name: 'proj', version: '1.0.0' });
+      // Only prefix-colliding packages exist in the store — `postcss` itself
+      // was never installed. The trailing "@" in the match prefix must
+      // prevent "postcss-import@1.0.0" / "postcss-js@2.0.0" from being
+      // mistaken for a copy of "postcss".
+      writePnpmStoreVersion(dir, 'postcss-import', '1.0.0');
+      writePnpmStoreVersion(dir, 'postcss-js', '2.0.0');
+      // No CLI fallback data either — filesystem probe genuinely has nothing
+      // for "postcss".
+      execAsyncMock.mockResolvedValue({ stdout: '[]', stderr: '' });
+
+      const pkgs: UpdatePackage[] = [{ name: 'postcss', targetVersion: '8.5.26' }];
+      const results = await applyOverrides(pkgs, 'pnpm', dir, 'test-project');
+
+      expect(results[0].success).toBe(true); // inconclusive is not a hard failure
+      expect(results[0].resolvedVersion).toBeUndefined();
+      expect(results[0].output).toMatch(/could not verify postcss's resolved version/);
     });
 
     it('falls back to `pnpm list --json` when the filesystem probe (root + .pnpm store) finds nothing', async () => {

--- a/src/lib/updaters/override.ts
+++ b/src/lib/updaters/override.ts
@@ -86,6 +86,38 @@ function findViolatingVersions(installedVersions: string[], targetVersion: strin
   return installedVersions.filter(v => !versionSatisfiesTarget(v, targetVersion));
 }
 
+/**
+ * Pick a single representative version out of a set of discovered copies —
+ * used both to report "what resolved" after an override and to read "what's
+ * currently installed" before one. Prefers the root copy when it's a
+ * parseable version (most representative of what a plain
+ * `node_modules/<pkg>` look would show); otherwise the highest of the
+ * remaining copies.
+ *
+ * Filters to parseable semver BEFORE sorting, and does not trust `root`
+ * blindly either. This matters: `semver.rcompare`/`semver.compare` and
+ * `semver.major` all THROW on an unparseable version, while
+ * `Array.prototype.sort` never invokes its comparator for a single-element
+ * array — so a lone garbage `version` field was silently accepted and only
+ * a *second*, differently-shaped copy would trigger the throw. That throw
+ * was getting swallowed by this file's catch-all, discarding every
+ * already-computed violating version along with it and leaving
+ * `resolvedVersion: undefined`, `success: true`, no warning at all — worse
+ * than the pre-fix `existsSync` no-op, because the violating versions were
+ * in hand and got thrown away instead of reported.
+ */
+export function pickPrimaryVersion(root: string | undefined, all: string[]): string | undefined {
+  if (root && semver.valid(root, { loose: true })) return root;
+  const parseable = all.filter(v => semver.valid(v, { loose: true }));
+  return parseable.length > 0 ? parseable.slice().sort(semver.rcompare)[0] : undefined;
+}
+
+/** The lowest (most vulnerable) parseable version among a set — used to report a representative offender when copies violate the floor. */
+function worstVersion(versions: string[]): string | undefined {
+  const parseable = versions.filter(v => semver.valid(v, { loose: true }));
+  return parseable.length > 0 ? parseable.slice().sort(semver.compare)[0] : undefined;
+}
+
 function readVersionField(pkgJsonPath: string): string | undefined {
   try {
     if (!existsSync(pkgJsonPath)) return undefined;
@@ -116,6 +148,17 @@ function readVersionField(pkgJsonPath: string): string | undefined {
  * different versions simultaneously. Stopping at the first hit would miss
  * exactly the "top-level fix, vulnerable nested copy survives" class this
  * project already tracks as issue #80.
+ *
+ * Only looks at `<cwd>/node_modules/.pnpm`. In a monorepo/workspace, the
+ * `.pnpm` store typically lives at the workspace root, not inside an
+ * individual workspace member's directory — if `cwd` here is a workspace
+ * member rather than the root, this returns `[]` for a package that's
+ * genuinely installed, and callers fall through to the `pnpm list` CLI
+ * fallback (which runs from the same `cwd` but asks pnpm itself, so it
+ * isn't subject to this same-directory limitation). Not fixed here because
+ * `applyOverrides`/`removeOverrideConflicts`/`cleanStaleOverrides` all
+ * already operate per-project on a single `cwd` with no workspace-root
+ * concept threaded through this file.
  */
 function findPnpmStoreVersions(cwd: string, pkgName: string): string[] {
   const storeDir = join(cwd, 'node_modules', '.pnpm');
@@ -153,7 +196,7 @@ function findPnpmStoreVersions(cwd: string, pkgName: string): string[] {
  * here, for a verification step that only needs to confirm an override
  * took effect, would be a much bigger change than this fix calls for.
  */
-function findAllInstalledVersions(cwd: string, pkgName: string): { root?: string; all: string[] } {
+export function findAllInstalledVersions(cwd: string, pkgName: string): { root?: string; all: string[] } {
   const root = readVersionField(join(cwd, 'node_modules', pkgName, 'package.json'));
   const all = new Set<string>(findPnpmStoreVersions(cwd, pkgName));
   if (root) all.add(root);
@@ -180,7 +223,15 @@ function findAllInstalledVersions(cwd: string, pkgName: string): { root?: string
  */
 async function queryPnpmForVersions(cwd: string, pkgName: string): Promise<string[]> {
   try {
-    const { stdout } = await execAsync(`pnpm list ${pkgName} --json --depth Infinity`, { cwd, timeout: 15000 });
+    // promisify(exec) defaults to a 1 MB stdout buffer. Measured on this
+    // repo, `pnpm list react --json --depth Infinity` alone is 237 KB —
+    // a monorepo resolving several packages this deep would exceed 1 MB
+    // and get its child process killed, silently degrading this fallback
+    // to "could not verify" on exactly the large projects it exists to
+    // help. Match the maxBuffer convention already used by other
+    // JSON-producing execAsync calls in this codebase (cve-lite-db.ts,
+    // security/override-audit.ts — 64 MB).
+    const { stdout } = await execAsync(`pnpm list ${pkgName} --json --depth Infinity`, { cwd, timeout: 15000, maxBuffer: 64 * 1024 * 1024 });
     const versions = new Set<string>();
     const visit = (node: unknown, key?: string): void => {
       if (Array.isArray(node)) {
@@ -497,23 +548,41 @@ export async function applyOverrides(
             meta: { package: pkg.name, targetVersion: pkg.targetVersion, writtenRange },
           });
         } else {
-          resolvedVersion = probe.root ?? probe.versions.slice().sort(semver.rcompare)[0];
-
-          // Check EVERY discovered copy, not just the one being reported —
-          // the .pnpm store (or, in principle, a nested npm copy) can hold
-          // several versions of the same package at once, and a floor
-          // satisfied at the root with a vulnerable copy still nested
-          // elsewhere is exactly the false-clear class this project already
-          // tracks as issue #80.
+          // Check EVERY discovered copy BEFORE deciding what to report as
+          // "the" resolved version — the .pnpm store (or, in principle, a
+          // nested npm copy) can hold several versions of the same package
+          // at once, and a floor satisfied at the root with a vulnerable
+          // copy still nested elsewhere is exactly the false-clear class
+          // this project already tracks as issue #80. Computing this first,
+          // and choosing resolvedVersion based on the outcome, also avoids
+          // a subtler version of the same false-clear: if resolvedVersion
+          // were picked independently (e.g. "root, or else the highest
+          // copy") it could report a clean-looking version even when a
+          // different, violating copy is what actually got flagged below —
+          // the structured field must not read as clean when a violating
+          // copy exists.
           const violating = findViolatingVersions(probe.versions, pkg.targetVersion);
 
           if (violating.length > 0) {
+            // Report the worst (most vulnerable) violator as the
+            // structured resolvedVersion, not the best-looking copy — a
+            // consumer filtering history on this field should see the
+            // problem, not a false clear. pickPrimaryVersion/worstVersion
+            // both filter to parseable semver before sorting: an
+            // unparseable `version` field must not crash this block and
+            // silently discard every violation already found (see the
+            // pickPrimaryVersion doc comment for how that happened before).
+            resolvedVersion = worstVersion(violating);
             verifyWarning = ` ⚠ override written but ${pkg.name} resolved to ${violating.join(', ')} (does not satisfy ${writtenRange}) — may need lockfile reset`;
             logger.warn('patches', 'override_version_mismatch', `Override for ${pkg.name}: expected ${writtenRange}, found violating cop${violating.length === 1 ? 'y' : 'ies'}: ${violating.join(', ')}`, {
               projectId,
               meta: { package: pkg.name, expected: pkg.targetVersion, writtenRange, violatingVersions: violating, allVersions: probe.versions },
             });
-          } else if (resolvedVersion) {
+          } else {
+            resolvedVersion = pickPrimaryVersion(probe.root, probe.versions);
+          }
+
+          if (violating.length === 0 && resolvedVersion && semver.valid(resolvedVersion, { loose: true })) {
             // Satisfies the floor — not a failure. But a resolved major
             // beyond the one that was targeted is exactly the kind of event
             // a bare `>=` floor (no ceiling, by owner decision) makes

--- a/src/lib/updaters/override.ts
+++ b/src/lib/updaters/override.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
+import semver from 'semver';
 import { execAsync, NPM_INSTALL_TIMEOUT, type UpdatePackage, type UpdateResult } from './common';
 import { addPatchHistoryEntry, generatePatchId } from '@/lib/patch-storage';
 import { getUpdateType } from '@/lib/patch-scanner';
@@ -7,6 +8,49 @@ import { logger } from '@/lib/logger';
 
 function pkgJsonIndent(raw: string): string {
   return raw.match(/^(\s+)/m)?.[1] || '  ';
+}
+
+/**
+ * Convert a concrete target version into a caret ("floor") range so that
+ * package-manager overrides stop hard-pinning the fleet to a single exact
+ * version forever (see #postcss-floor-audit: 29/32 projects were stuck on an
+ * exact postcss pin that blocked routine updates past a vulnerable version).
+ *
+ * - Concrete versions ("8.5.26") become a caret floor ("^8.5.26") so a normal
+ *   `update` can still move the resolved version forward within the same
+ *   major line, but never below the floor.
+ * - Dist-tags ("latest", "next", "canary") and anything else that isn't a
+ *   single concrete semver (including ranges that are already ranges) pass
+ *   through unchanged — you cannot caret a tag, and re-wrapping an existing
+ *   range would be wrong.
+ * - Prereleases ("1.0.0-beta.1") are floored the same way as any other
+ *   concrete version. `^1.0.0-beta.1` only matches later prereleases of the
+ *   *same* major.minor.patch plus the eventual stable 1.0.0 release — it will
+ *   not reach into a different prerelease line. That's inherent to how npm's
+ *   semver treats prerelease tags (a range only admits a prerelease that
+ *   shares [major,minor,patch] with one of its comparators), not something
+ *   this function can or should work around. A prerelease override is
+ *   already a narrow, deliberate pin, so that narrower floor is the correct
+ *   behavior rather than a special case to avoid.
+ */
+export function toFloorRange(version: string): string {
+  const parsed = semver.valid(version, { loose: true });
+  return parsed ? `^${parsed}` : version;
+}
+
+/**
+ * Whether an installed version satisfies a target that applyOverrides wrote
+ * as a floor. For concrete targets, "installed >= target" counts as success
+ * — resolving higher than the floor is the point, not a mismatch. Falls back
+ * to exact string equality when either side isn't a parseable concrete
+ * version (dist-tag targets like "latest"), matching the pre-floor behavior.
+ */
+function meetsFloorTarget(installedVersion: string | undefined, targetVersion: string): boolean {
+  if (!installedVersion) return false;
+  const installed = semver.valid(installedVersion, { loose: true });
+  const target = semver.valid(targetVersion, { loose: true });
+  if (installed && target) return semver.gte(installed, target);
+  return installedVersion === targetVersion;
 }
 
 /** Remove override/resolution entries that conflict with a direct-dep update. */
@@ -24,11 +68,31 @@ export function removeOverrideConflicts(
     const yarnResolutions: Record<string, string> | undefined = pkgJson?.resolutions;
     let changed = false;
 
+    // An existing override/resolution is only a "conflict" with the incoming
+    // direct-dep update if it would actually block that update from landing.
+    // Once applyOverrides writes floors ("^8.5.23") instead of exact pins,
+    // a plain string comparison against the new target ("8.5.26") is always
+    // unequal — that would delete the very floor we just wrote, on every
+    // subsequent direct-dep update. Test satisfaction instead: keep the
+    // existing range if the new target already falls within it.
+    const conflictsWithTarget = (pinned: string, targetVersion: string, isFloating: boolean): boolean => {
+      if (isFloating) return true; // latest/next/canary always force a fresh, unpinned resolution
+      const range = semver.validRange(pinned, { loose: true });
+      const target = semver.valid(targetVersion, { loose: true });
+      if (range && target) {
+        return !semver.satisfies(target, range, { loose: true, includePrerelease: true });
+      }
+      // Either side isn't parseable semver (e.g. an npm "$pkg" alias or a git
+      // URL) — fall back to the original strict string comparison so those
+      // unusual specifiers keep their prior, well-understood behavior.
+      return pinned !== targetVersion;
+    };
+
     for (const pkg of directPkgs) {
       const isFloating = /^(latest|next|canary)$/.test(pkg.targetVersion);
       if (pnpmOverrides?.[pkg.name] !== undefined) {
         const pinned = pnpmOverrides[pkg.name];
-        if (isFloating || pinned !== pkg.targetVersion) {
+        if (conflictsWithTarget(pinned, pkg.targetVersion, isFloating)) {
           delete pkgJson.pnpm.overrides[pkg.name];
           changed = true;
           logger.info('patches', 'override_conflict_removed', `Removed conflicting pnpm.overrides[${pkg.name}]=${pinned} before updating to ${pkg.targetVersion}`, { projectId, meta: { package: pkg.name } });
@@ -36,7 +100,7 @@ export function removeOverrideConflicts(
       }
       if (npmOverrides?.[pkg.name] !== undefined) {
         const pinned = npmOverrides[pkg.name];
-        if (isFloating || pinned !== pkg.targetVersion) {
+        if (conflictsWithTarget(pinned, pkg.targetVersion, isFloating)) {
           delete pkgJson.overrides[pkg.name];
           changed = true;
           logger.info('patches', 'override_conflict_removed', `Removed conflicting overrides[${pkg.name}]=${pinned} before updating to ${pkg.targetVersion}`, { projectId, meta: { package: pkg.name } });
@@ -44,7 +108,7 @@ export function removeOverrideConflicts(
       }
       if (yarnResolutions?.[pkg.name] !== undefined) {
         const pinned = yarnResolutions[pkg.name];
-        if (isFloating || pinned !== pkg.targetVersion) {
+        if (conflictsWithTarget(pinned, pkg.targetVersion, isFloating)) {
           delete pkgJson.resolutions[pkg.name];
           changed = true;
           logger.info('patches', 'override_conflict_removed', `Removed conflicting resolutions[${pkg.name}]=${pinned} before updating to ${pkg.targetVersion}`, { projectId, meta: { package: pkg.name } });
@@ -85,11 +149,25 @@ export function cleanStaleOverrides(
         const nmPath = join(cwd, 'node_modules', lookupPkg, 'package.json');
         if (existsSync(nmPath)) {
           const installed = JSON.parse(readFileSync(nmPath, 'utf-8')).version;
+          // Only exact pins ("8.5.15") are ever candidates for staleness
+          // removal here — deliberately, not incidentally. A range-valued
+          // override (the "^8.5.23" floors this file now writes) resolving
+          // to something newer than its base is the expected, desired
+          // outcome, not staleness: the floor is still doing its job of
+          // keeping the fleet off the vulnerable version. Removing it would
+          // strip that security floor entirely. So range-shaped values
+          // (anything starting with <, >, =, ^, or ~) are skipped outright,
+          // same as before — only bare exact versions are compared.
           if (installed && pinnedVersion && !/^[<>=^~]/.test(pinnedVersion)) {
-            const iv = installed.split('.').map((n: string) => parseInt(n, 10) || 0);
-            const pv = pinnedVersion.split('.').map((n: string) => parseInt(n, 10) || 0);
-            const isNewer = iv[0] > pv[0] || (iv[0] === pv[0] && iv[1] > pv[1]) || (iv[0] === pv[0] && iv[1] === pv[1] && (iv[2] ?? 0) > (pv[2] ?? 0));
-            if (isNewer) staleKeys.push(overridePkg);
+            const iv = semver.valid(installed, { loose: true });
+            const pv = semver.valid(pinnedVersion, { loose: true });
+            // Proper semver comparison instead of hand-rolled parseInt
+            // splitting, which mishandled prereleases (1.0.0-beta.1 vs
+            // 1.0.0) and build metadata (1.0.0+build vs 1.0.0). If either
+            // side isn't a parseable concrete version, skip rather than
+            // guess — the old code silently treated unparseable segments as
+            // 0, which could misfire as "newer" on garbage input.
+            if (iv && pv && semver.gt(iv, pv)) staleKeys.push(overridePkg);
           }
         }
       } catch { /* skip entry */ }
@@ -143,20 +221,26 @@ export async function applyOverrides(
     if (packageManager === 'pnpm') {
       if (!pkgJson.pnpm) pkgJson.pnpm = {};
       if (!pkgJson.pnpm.overrides) pkgJson.pnpm.overrides = {};
-      for (const pkg of overridePkgs) pkgJson.pnpm.overrides[pkg.name] = pkg.targetVersion;
+      for (const pkg of overridePkgs) pkgJson.pnpm.overrides[pkg.name] = toFloorRange(pkg.targetVersion);
     } else if (packageManager === 'npm') {
       if (!pkgJson.overrides) pkgJson.overrides = {};
       for (const pkg of overridePkgs) {
         if (pkgJson.dependencies?.[pkg.name] !== undefined) {
-          pkgJson.dependencies[pkg.name] = pkg.targetVersion;
+          // Direct dependency: npm can't apply `overrides` to a package that's
+          // also a direct dependency, so the only way to move it is to rewrite
+          // the direct specifier itself. That specifier is exactly as prone to
+          // the "exact pin blocks future updates" problem this whole change
+          // exists to fix, so it gets the same floor treatment as the
+          // override-only path below — not left as an exact pin silently.
+          pkgJson.dependencies[pkg.name] = toFloorRange(pkg.targetVersion);
         } else {
           if (pkgJson.devDependencies?.[pkg.name] !== undefined) delete pkgJson.devDependencies[pkg.name];
-          pkgJson.overrides[pkg.name] = pkg.targetVersion;
+          pkgJson.overrides[pkg.name] = toFloorRange(pkg.targetVersion);
         }
       }
     } else {
       if (!pkgJson.resolutions) pkgJson.resolutions = {};
-      for (const pkg of overridePkgs) pkgJson.resolutions[pkg.name] = pkg.targetVersion;
+      for (const pkg of overridePkgs) pkgJson.resolutions[pkg.name] = toFloorRange(pkg.targetVersion);
     }
 
     writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, pkgJsonIndent(pkgJsonRaw)) + '\n', 'utf-8');
@@ -177,7 +261,9 @@ export async function applyOverrides(
       const anyResolved = overridePkgs.some(pkg => {
         try {
           const p = join(cwd, 'node_modules', pkg.name, 'package.json');
-          return existsSync(p) && JSON.parse(readFileSync(p, 'utf-8')).version === pkg.targetVersion;
+          if (!existsSync(p)) return false;
+          const installedVersion = JSON.parse(readFileSync(p, 'utf-8')).version;
+          return meetsFloorTarget(installedVersion, pkg.targetVersion);
         } catch { return false; }
       });
       if (!anyResolved) throw new Error(err.stderr || err.message || 'Install after override failed');
@@ -189,7 +275,12 @@ export async function applyOverrides(
         const installedPkgPath = join(cwd, 'node_modules', pkg.name, 'package.json');
         if (existsSync(installedPkgPath)) {
           const installedVersion = JSON.parse(readFileSync(installedPkgPath, 'utf-8')).version;
-          if (installedVersion !== pkg.targetVersion) {
+          // With a caret floor written instead of an exact pin, resolving to
+          // something newer than the target is success, not a mismatch — the
+          // floor did its job. Only warn when the resolved version doesn't
+          // meet the floor (or, for dist-tag targets, isn't an exact match,
+          // same as the pre-floor behavior).
+          if (!meetsFloorTarget(installedVersion, pkg.targetVersion)) {
             verifyWarning = ` ⚠ override written but ${pkg.name} resolved to ${installedVersion} — may need lockfile reset`;
             logger.warn('patches', 'override_version_mismatch', `Override for ${pkg.name}: expected ${pkg.targetVersion}, got ${installedVersion}`, {
               projectId,

--- a/src/lib/updaters/override.ts
+++ b/src/lib/updaters/override.ts
@@ -88,34 +88,63 @@ function findViolatingVersions(installedVersions: string[], targetVersion: strin
 
 /**
  * Pick a single representative version out of a set of discovered copies —
- * used both to report "what resolved" after an override and to read "what's
- * currently installed" before one. Prefers the root copy when it's a
- * parseable version (most representative of what a plain
- * `node_modules/<pkg>` look would show); otherwise the highest of the
+ * used to report "what resolved" after an override once every copy has
+ * already been confirmed to satisfy the floor (see the verify loop in
+ * `applyOverrides`; callers that need "is anything still below a target" —
+ * a downgrade guard — must use `pickLowestVersion` on the full set instead,
+ * not this function: they ask a different question, and this one answering
+ * "highest" would silently paper over a still-vulnerable copy). Prefers the
+ * root copy when it's a parseable version (most representative of what a
+ * plain `node_modules/<pkg>` look would show); otherwise the highest of the
  * remaining copies.
  *
- * Filters to parseable semver BEFORE sorting, and does not trust `root`
- * blindly either. This matters: `semver.rcompare`/`semver.compare` and
- * `semver.major` all THROW on an unparseable version, while
- * `Array.prototype.sort` never invokes its comparator for a single-element
- * array — so a lone garbage `version` field was silently accepted and only
- * a *second*, differently-shaped copy would trigger the throw. That throw
- * was getting swallowed by this file's catch-all, discarding every
- * already-computed violating version along with it and leaving
- * `resolvedVersion: undefined`, `success: true`, no warning at all — worse
- * than the pre-fix `existsSync` no-op, because the violating versions were
- * in hand and got thrown away instead of reported.
+ * Filters to parseable semver BEFORE sorting — with the loose flag passed
+ * through to BOTH the filter and the sort comparator, not just the filter.
+ * That distinction matters on its own: `semver.valid(v, {loose:true})`
+ * accepts version strings (`1.02.3`, leading zeros; `=1.2.3`, an equals
+ * prefix; `1.2.3-beta.01`, a leading-zero prerelease segment) that
+ * `semver.compare`/`semver.rcompare` — called bare, as a `.sort()`
+ * comparator, which invokes them with exactly two arguments and so never
+ * passes `loose` — reject and THROW on. A version that passes the loose
+ * filter but hits the strict sort would throw regardless of which end
+ * (`pickLowestVersion` or this function) picked it.
+ *
+ * Also: `Array.prototype.sort` never invokes its comparator for a
+ * single-element array, so a lone garbage `version` field was always
+ * silently accepted, and only a *second*, differently-shaped copy would
+ * ever trigger the throw — which is why single-copy tests alone can't
+ * catch this class of bug. Any throw here would be caught by this file's
+ * outer catch-all, discarding an already-computed violation report along
+ * with it (see the caller in `applyOverrides`, which computes and logs the
+ * violation warning *before* calling into version selection for exactly
+ * this reason — so a throw during selection can no longer un-report a
+ * violation that was already detected and logged).
  */
 export function pickPrimaryVersion(root: string | undefined, all: string[]): string | undefined {
   if (root && semver.valid(root, { loose: true })) return root;
   const parseable = all.filter(v => semver.valid(v, { loose: true }));
-  return parseable.length > 0 ? parseable.slice().sort(semver.rcompare)[0] : undefined;
+  return parseable.length > 0 ? parseable.slice().sort((a, b) => semver.rcompare(a, b, { loose: true }))[0] : undefined;
 }
 
-/** The lowest (most vulnerable) parseable version among a set — used to report a representative offender when copies violate the floor. */
-function worstVersion(versions: string[]): string | undefined {
+/**
+ * The lowest parseable version among a set of discovered copies. Used both
+ * to report a representative offender when copies violate a floor, and — by
+ * `route.ts`, for the pre-install downgrade guard — to answer "is anything
+ * still below the target", which requires the WORST case among all copies,
+ * not `pickPrimaryVersion`'s root-or-highest answer. Feeding a downgrade
+ * guard the highest copy is actively wrong: on an isolated pnpm layout with
+ * a vulnerable copy at 8.4.31 and a clean one at 8.5.30 against a target of
+ * 8.5.26, the highest copy (8.5.30) reads as "already past this fix" and
+ * refuses the entire update — the exact issue-#80 multi-copy shape this
+ * effort exists to catch, except now refusing to even attempt the fix
+ * rather than merely failing to verify it.
+ *
+ * Same loose-in-both-filter-and-sort treatment as `pickPrimaryVersion`, for
+ * the same reason (see that function's doc comment).
+ */
+export function pickLowestVersion(versions: string[]): string | undefined {
   const parseable = versions.filter(v => semver.valid(v, { loose: true }));
-  return parseable.length > 0 ? parseable.slice().sort(semver.compare)[0] : undefined;
+  return parseable.length > 0 ? parseable.slice().sort((a, b) => semver.compare(a, b, { loose: true }))[0] : undefined;
 }
 
 function readVersionField(pkgJsonPath: string): string | undefined {
@@ -564,20 +593,26 @@ export async function applyOverrides(
           const violating = findViolatingVersions(probe.versions, pkg.targetVersion);
 
           if (violating.length > 0) {
-            // Report the worst (most vulnerable) violator as the
-            // structured resolvedVersion, not the best-looking copy — a
-            // consumer filtering history on this field should see the
-            // problem, not a false clear. pickPrimaryVersion/worstVersion
-            // both filter to parseable semver before sorting: an
-            // unparseable `version` field must not crash this block and
-            // silently discard every violation already found (see the
-            // pickPrimaryVersion doc comment for how that happened before).
-            resolvedVersion = worstVersion(violating);
+            // Assign the warning and log it BEFORE computing resolvedVersion
+            // below. This ordering is the structural fix, not just the loose
+            // flag on the sort: version selection can still throw on input
+            // this file hasn't anticipated, and if that throw happened
+            // before the violation was reported, it would propagate to the
+            // outer catch-all and discard the violation report along with
+            // it — silent `success: true`, no warning, nothing, despite the
+            // violating versions having already been found. Reporting the
+            // violation first means a subsequent throw can only cost the
+            // structured `resolvedVersion` field, never the warning itself.
             verifyWarning = ` ⚠ override written but ${pkg.name} resolved to ${violating.join(', ')} (does not satisfy ${writtenRange}) — may need lockfile reset`;
             logger.warn('patches', 'override_version_mismatch', `Override for ${pkg.name}: expected ${writtenRange}, found violating cop${violating.length === 1 ? 'y' : 'ies'}: ${violating.join(', ')}`, {
               projectId,
               meta: { package: pkg.name, expected: pkg.targetVersion, writtenRange, violatingVersions: violating, allVersions: probe.versions },
             });
+            // Report the worst (most vulnerable) violator as the structured
+            // resolvedVersion, not the best-looking copy — a consumer
+            // filtering history on this field should see the problem, not a
+            // false clear.
+            resolvedVersion = pickLowestVersion(violating);
           } else {
             resolvedVersion = pickPrimaryVersion(probe.root, probe.versions);
           }

--- a/src/lib/updaters/override.ts
+++ b/src/lib/updaters/override.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import semver from 'semver';
 import { execAsync, NPM_INSTALL_TIMEOUT, type UpdatePackage, type UpdateResult } from './common';
@@ -50,10 +50,16 @@ export function toFloorRange(version: string): string {
   return parsed ? `>=${parsed}` : version;
 }
 
+/** The range applyOverrides actually wrote for a target, parsed for satisfaction checks. */
+function writtenRangeInfo(targetVersion: string): { writtenRange: string; range: string | null } {
+  const writtenRange = toFloorRange(targetVersion);
+  return { writtenRange, range: semver.validRange(writtenRange, { loose: true }) };
+}
+
 /**
- * Whether an installed version satisfies the override value applyOverrides
- * actually wrote for this target — `toFloorRange(targetVersion)` — rather
- * than a plain "installed >= target" scalar comparison.
+ * Whether a single installed version satisfies the override value
+ * applyOverrides actually wrote for this target — `toFloorRange(targetVersion)`
+ * — rather than a plain "installed >= target" scalar comparison.
  *
  * This exists to verify the override actually took effect. A plain scalar
  * comparison is too permissive for that job: a keyed pnpm override
@@ -69,12 +75,163 @@ export function toFloorRange(version: string): string {
  * parseable range (dist-tag targets like "latest"), matching the pre-floor
  * behavior.
  */
-function satisfiesWrittenOverride(installedVersion: string | undefined, targetVersion: string): boolean {
-  if (!installedVersion) return false;
-  const written = toFloorRange(targetVersion);
-  const range = semver.validRange(written, { loose: true });
+function versionSatisfiesTarget(installedVersion: string, targetVersion: string): boolean {
+  const { range } = writtenRangeInfo(targetVersion);
   if (range) return semver.satisfies(installedVersion, range, { loose: true });
   return installedVersion === targetVersion;
+}
+
+/** Every installed version, among a set of candidates, that does NOT satisfy the written override. */
+function findViolatingVersions(installedVersions: string[], targetVersion: string): string[] {
+  return installedVersions.filter(v => !versionSatisfiesTarget(v, targetVersion));
+}
+
+function readVersionField(pkgJsonPath: string): string | undefined {
+  try {
+    if (!existsSync(pkgJsonPath)) return undefined;
+    const parsed = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
+    return typeof parsed?.version === 'string' ? parsed.version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * pnpm's default node-linker (`isolated`) does not create a root
+ * `node_modules/<pkg>` entry for a purely-transitive package — it lives in
+ * the content-addressable `.pnpm` virtual store instead, at
+ * `node_modules/.pnpm/<name>@<version>[_peerHash]/node_modules/<name>/package.json`
+ * (scoped names have their "/" replaced with "+" in the store directory
+ * name — confirmed against this repo's own `pnpm list --json` output, e.g.
+ * `@vitest/ui` stores as `.pnpm/@vitest+ui@4.1.9_.../node_modules/@vitest/ui`).
+ * A root-only `existsSync` check is a silent no-op for exactly this layout —
+ * confirmed against a real fleet project (bosun-super-admin) that uses
+ * pnpm's default isolated linker and has no root `node_modules/postcss` at
+ * all. hexops's own `.npmrc` forces `node-linker=hoisted` (a node-pty
+ * workaround), which is why this blind spot never surfaced in local
+ * development.
+ *
+ * Collects every distinct version found in the store, not just the first —
+ * the store can (and does) hold multiple copies of the same package at
+ * different versions simultaneously. Stopping at the first hit would miss
+ * exactly the "top-level fix, vulnerable nested copy survives" class this
+ * project already tracks as issue #80.
+ */
+function findPnpmStoreVersions(cwd: string, pkgName: string): string[] {
+  const storeDir = join(cwd, 'node_modules', '.pnpm');
+  if (!existsSync(storeDir)) return [];
+  let entries: string[];
+  try {
+    entries = readdirSync(storeDir);
+  } catch {
+    return [];
+  }
+  const prefix = `${pkgName.replace('/', '+')}@`;
+  const versions = new Set<string>();
+  for (const entry of entries) {
+    if (!entry.startsWith(prefix)) continue;
+    const v = readVersionField(join(storeDir, entry, 'node_modules', pkgName, 'package.json'));
+    if (v) versions.add(v);
+  }
+  return Array.from(versions);
+}
+
+/**
+ * Every distinct installed version of a package this function can find on
+ * disk, across every layout it knows how to read: the flat root
+ * `node_modules` (npm/yarn, and pnpm's hoisted node-linker) and pnpm's
+ * isolated-linker `.pnpm` virtual store. Synchronous and filesystem-only —
+ * no package-manager queries — so it's safe to call from both the
+ * install-failure fallback and the main verification path.
+ *
+ * Deliberately does NOT walk arbitrary nested
+ * `node_modules/<parent>/node_modules/<pkg>` paths (the npm/yarn nested-copy
+ * shape). That's a materially larger surface already handled elsewhere in
+ * this codebase for a different purpose — see `resolveInstalledVersion` in
+ * patch-scanner.ts, which uses npm audit's `nodes` hints to target specific
+ * nested paths flagged by an audit run. Reimplementing a full recursive walk
+ * here, for a verification step that only needs to confirm an override
+ * took effect, would be a much bigger change than this fix calls for.
+ */
+function findAllInstalledVersions(cwd: string, pkgName: string): { root?: string; all: string[] } {
+  const root = readVersionField(join(cwd, 'node_modules', pkgName, 'package.json'));
+  const all = new Set<string>(findPnpmStoreVersions(cwd, pkgName));
+  if (root) all.add(root);
+  return { root, all: Array.from(all) };
+}
+
+/**
+ * Last-resort fallback when the filesystem probe (root + `.pnpm` store)
+ * finds nothing at all. That can genuinely mean the override never took
+ * effect, but it can also mean a custom store location, a workspace
+ * hoisting pattern, or some other layout this file doesn't know how to
+ * read filesystem-side. Only attempted for pnpm — the concretely-identified
+ * blind spot (bosun-super-admin) — not npm/yarn: those always hoist flatly
+ * by design, so the root `node_modules` check already covers the
+ * overwhelming majority of real layouts there, and taking on `npm ls`
+ * output-parsing quirks wasn't warranted for this fix.
+ *
+ * Parses `pnpm list <pkg> --json --depth Infinity` by walking
+ * `dependencies`/`devDependencies`/`optionalDependencies` at every level and
+ * collecting `.version` only where the enclosing key equals the package
+ * name being looked up (verified against this repo's own real output —
+ * blindly collecting every "version" field anywhere in the tree would also
+ * pick up unrelated ancestor packages' own versions).
+ */
+async function queryPnpmForVersions(cwd: string, pkgName: string): Promise<string[]> {
+  try {
+    const { stdout } = await execAsync(`pnpm list ${pkgName} --json --depth Infinity`, { cwd, timeout: 15000 });
+    const versions = new Set<string>();
+    const visit = (node: unknown, key?: string): void => {
+      if (Array.isArray(node)) {
+        for (const item of node) visit(item, key);
+        return;
+      }
+      if (!node || typeof node !== 'object') return;
+      const obj = node as Record<string, unknown>;
+      if (key === pkgName && typeof obj.version === 'string' && semver.valid(obj.version, { loose: true })) {
+        versions.add(obj.version);
+      }
+      for (const depsField of ['dependencies', 'devDependencies', 'optionalDependencies']) {
+        const deps = obj[depsField];
+        if (deps && typeof deps === 'object') {
+          for (const [depName, depNode] of Object.entries(deps as Record<string, unknown>)) {
+            visit(depNode, depName);
+          }
+        }
+      }
+    };
+    visit(JSON.parse(stdout));
+    return Array.from(versions);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Full resolved-version lookup used by the post-install verification path:
+ * filesystem probe first (root + `.pnpm` store, covers the concretely
+ * identified isolated-linker blind spot), then a `pnpm list` fallback only
+ * when the filesystem probe is completely empty. `verified: false` means
+ * neither method found anything — genuinely inconclusive, not "assume fine"
+ * and not "assume failed". Callers must handle that state explicitly rather
+ * than letting it fall through as a silent pass, which is the exact defect
+ * this replaces (a bare `existsSync(node_modules/<pkg>)` check that quietly
+ * no-ops — no warning, `success: true` — on any project using pnpm's
+ * default isolated linker).
+ */
+async function resolveInstalledVersions(
+  cwd: string,
+  pkgName: string,
+  packageManager: string,
+): Promise<{ root?: string; versions: string[]; verified: boolean }> {
+  const fsResult = findAllInstalledVersions(cwd, pkgName);
+  if (fsResult.all.length > 0) return { root: fsResult.root, versions: fsResult.all, verified: true };
+  if (packageManager === 'pnpm') {
+    const cliVersions = await queryPnpmForVersions(cwd, pkgName);
+    if (cliVersions.length > 0) return { root: undefined, versions: cliVersions, verified: true };
+  }
+  return { root: undefined, versions: [], verified: false };
 }
 
 /** Remove override/resolution entries that conflict with a direct-dep update. */
@@ -288,19 +445,27 @@ export async function applyOverrides(
       installOutput = `$ ${installCmd}\n${err.stdout || ''}${err.stderr || ''}`;
       const anyResolved = overridePkgs.some(pkg => {
         try {
-          const p = join(cwd, 'node_modules', pkg.name, 'package.json');
-          if (!existsSync(p)) return false;
-          const installedVersion = JSON.parse(readFileSync(p, 'utf-8')).version;
-          // A version on disk that's identical to what was installed BEFORE
-          // this override ran is not evidence the install succeeded — it's
-          // evidence the install failed and left the pre-existing tree
-          // untouched. Without this guard, a failed install (registry 5xx,
-          // ERESOLVE, disk full) with a stale-but-already-satisfying copy in
-          // node_modules would get silently swallowed here, every package in
-          // this batch would report success, and the caller would go on to
-          // reconcile/audit a tree whose install never actually completed.
-          if (pkg.fromVersion && installedVersion === pkg.fromVersion) return false;
-          return satisfiesWrittenOverride(installedVersion, pkg.targetVersion);
+          // Filesystem-only probe (root + pnpm's .pnpm store) — no CLI
+          // fallback here. This runs only after the install command itself
+          // already failed; on ambiguity it's safer for this specific path
+          // to fall through to "not resolved" (favoring reporting the
+          // failure) than to spend another child-process round-trip trying
+          // to rescue an already-failing install.
+          const { all } = findAllInstalledVersions(cwd, pkg.name);
+          return all.some(v => {
+            // A version on disk that's identical to what was installed
+            // BEFORE this override ran is not evidence the install
+            // succeeded — it's evidence the install failed and left the
+            // pre-existing tree untouched. Without this guard, a failed
+            // install (registry 5xx, ERESOLVE, disk full) with a
+            // stale-but-already-satisfying copy already in node_modules
+            // would get silently swallowed here, every package in this
+            // batch would report success, and the caller would go on to
+            // reconcile/audit a tree whose install never actually
+            // completed.
+            if (pkg.fromVersion && v === pkg.fromVersion) return false;
+            return versionSatisfiesTarget(v, pkg.targetVersion);
+          });
         } catch { return false; }
       });
       if (!anyResolved) throw new Error(err.stderr || err.message || 'Install after override failed');
@@ -308,40 +473,79 @@ export async function applyOverrides(
 
     for (const pkg of overridePkgs) {
       let verifyWarning = '';
+      let resolvedVersion: string | undefined;
+      const { writtenRange } = writtenRangeInfo(pkg.targetVersion);
       try {
-        const installedPkgPath = join(cwd, 'node_modules', pkg.name, 'package.json');
-        if (existsSync(installedPkgPath)) {
-          const installedVersion = JSON.parse(readFileSync(installedPkgPath, 'utf-8')).version;
-          // With a `>=` floor written instead of an exact pin, resolving to
-          // something newer than the target is success, not a mismatch — the
-          // floor did its job. But this still has to be a real check, not a
-          // rubber stamp: compare against the range actually written
-          // (satisfiesWrittenOverride), not a bare "installed >= target"
-          // scalar, so a genuine mismatch (a keyed override, workspace
-          // catalog, or parent constraint steering resolution outside what
-          // we wrote) is still caught — see project issue #126, where a bare
-          // `>=` previously failed to move the resolved version under
-          // pnpm's node-linker=hoisted and this check is the only thing that
-          // detects that.
-          if (!satisfiesWrittenOverride(installedVersion, pkg.targetVersion)) {
-            verifyWarning = ` ⚠ override written but ${pkg.name} resolved to ${installedVersion} — may need lockfile reset`;
-            logger.warn('patches', 'override_version_mismatch', `Override for ${pkg.name}: expected ${pkg.targetVersion}, got ${installedVersion}`, {
+        // Isolated-layout-aware lookup (root node_modules, then the .pnpm
+        // store, then — for pnpm only — a `pnpm list` fallback). This is
+        // the only mechanism that catches project issue #126 (a bare
+        // floor failing to move the resolved version), so it has to
+        // actually run on the layout the project uses, not just the
+        // hoisted layout this worktree happens to force via .npmrc.
+        const probe = await resolveInstalledVersions(cwd, pkg.name, packageManager);
+
+        if (!probe.verified) {
+          // Could not find this package by ANY method — root, .pnpm store,
+          // or (for pnpm) a live query. This must be surfaced as "couldn't
+          // verify", not silently folded into "no warning = fine". Treating
+          // an inconclusive probe as success is exactly the defect being
+          // fixed: a root-only existsSync check that quietly no-ops on any
+          // project using pnpm's default isolated linker.
+          verifyWarning = ` ⚠ could not verify ${pkg.name}'s resolved version on disk (checked root node_modules and the pnpm store) — check manually`;
+          logger.warn('patches', 'override_verify_inconclusive', `Could not determine an installed version for ${pkg.name} after applying override ${writtenRange} — checked root node_modules and the pnpm store, found nothing`, {
+            projectId,
+            meta: { package: pkg.name, targetVersion: pkg.targetVersion, writtenRange },
+          });
+        } else {
+          resolvedVersion = probe.root ?? probe.versions.slice().sort(semver.rcompare)[0];
+
+          // Check EVERY discovered copy, not just the one being reported —
+          // the .pnpm store (or, in principle, a nested npm copy) can hold
+          // several versions of the same package at once, and a floor
+          // satisfied at the root with a vulnerable copy still nested
+          // elsewhere is exactly the false-clear class this project already
+          // tracks as issue #80.
+          const violating = findViolatingVersions(probe.versions, pkg.targetVersion);
+
+          if (violating.length > 0) {
+            verifyWarning = ` ⚠ override written but ${pkg.name} resolved to ${violating.join(', ')} (does not satisfy ${writtenRange}) — may need lockfile reset`;
+            logger.warn('patches', 'override_version_mismatch', `Override for ${pkg.name}: expected ${writtenRange}, found violating cop${violating.length === 1 ? 'y' : 'ies'}: ${violating.join(', ')}`, {
               projectId,
-              meta: { package: pkg.name, expected: pkg.targetVersion, actual: installedVersion },
+              meta: { package: pkg.name, expected: pkg.targetVersion, writtenRange, violatingVersions: violating, allVersions: probe.versions },
             });
+          } else if (resolvedVersion) {
+            // Satisfies the floor — not a failure. But a resolved major
+            // beyond the one that was targeted is exactly the kind of event
+            // a bare `>=` floor (no ceiling, by owner decision) makes
+            // possible and that someone should see surfaced in the patch
+            // log, not buried silently in a routine "applied" entry.
+            const targetSemver = semver.valid(pkg.targetVersion, { loose: true });
+            if (targetSemver) {
+              const resolvedMajor = semver.major(resolvedVersion);
+              const targetMajor = semver.major(targetSemver);
+              if (resolvedMajor > targetMajor) {
+                logger.warn('patches', 'override_major_jump', `Override for ${pkg.name}: requested ${writtenRange}, resolved to ${resolvedVersion} — a newer major (${resolvedMajor}) than targeted (${targetMajor})`, {
+                  projectId,
+                  meta: { package: pkg.name, expected: pkg.targetVersion, resolvedVersion, targetMajor, resolvedMajor },
+                });
+              }
+            }
           }
         }
       } catch { /* non-fatal */ }
 
+      const resolvedNote = resolvedVersion ? `, resolved ${resolvedVersion}` : '';
+
       results.push({
         package: pkg.name,
         success: true,
-        output: `Applied override: ${pkg.name}@${pkg.targetVersion}${verifyWarning}\n${installOutput}`,
+        output: `Applied override: ${pkg.name}@${writtenRange}${resolvedNote}${verifyWarning}\n${installOutput}`,
+        resolvedVersion,
       });
 
-      logger.info('patches', 'override_applied', `Applied override for ${pkg.name}@${pkg.targetVersion}`, {
+      logger.info('patches', 'override_applied', `Applied override for ${pkg.name}@${writtenRange}${resolvedNote}`, {
         projectId,
-        meta: { package: pkg.name, fromVersion: pkg.fromVersion || 'unknown', toVersion: pkg.targetVersion, packageManager, mechanism: 'override' },
+        meta: { package: pkg.name, fromVersion: pkg.fromVersion || 'unknown', toVersion: pkg.targetVersion, resolvedVersion, packageManager, mechanism: 'override' },
       });
 
       addPatchHistoryEntry({
@@ -351,10 +555,11 @@ export async function applyOverrides(
         package: pkg.name,
         fromVersion: pkg.fromVersion || 'unknown',
         toVersion: pkg.targetVersion,
+        resolvedVersion,
         updateType: pkg.fromVersion ? getUpdateType(pkg.fromVersion, pkg.targetVersion) : 'patch',
         trigger: 'manual',
         success: true,
-        output: `Override applied: ${pkg.name}@${pkg.targetVersion}${verifyWarning}`,
+        output: `Override applied: ${pkg.name}@${writtenRange}${resolvedNote}${verifyWarning}`,
       });
     }
   } catch (err) {

--- a/src/lib/updaters/override.ts
+++ b/src/lib/updaters/override.ts
@@ -11,45 +11,69 @@ function pkgJsonIndent(raw: string): string {
 }
 
 /**
- * Convert a concrete target version into a caret ("floor") range so that
+ * Convert a concrete target version into a `>=` ("floor") range so that
  * package-manager overrides stop hard-pinning the fleet to a single exact
  * version forever (see #postcss-floor-audit: 29/32 projects were stuck on an
  * exact postcss pin that blocked routine updates past a vulnerable version).
  *
- * - Concrete versions ("8.5.26") become a caret floor ("^8.5.26") so a normal
- *   `update` can still move the resolved version forward within the same
- *   major line, but never below the floor.
+ * Uses a bare `>=` floor, not a caret, by deliberate choice (owner decision):
+ * - Caret is inert below 1.0.0. `^0.0.3` expands to `>=0.0.3 <0.0.4-0` —
+ *   exactly one version, byte-identical in effect to the exact pin this
+ *   change exists to eliminate. `^0.5.1` caps at `<0.6.0-0`, and in the 0.x
+ *   line the *minor* is the breaking axis, so that cap is still too tight.
+ * - Caret also has a ceiling at the next major, so it can never admit a fix
+ *   that ships in a later major version — exactly the scenario a security
+ *   floor needs to survive.
+ * - `>=` matches the convention already used elsewhere in this repo's own
+ *   `package.json` overrides (`esbuild: ">=0.28.1"`, `qs`, `hono`, `ws`).
+ *
+ * - Concrete versions ("8.5.26") become a floor (">=8.5.26") so a normal
+ *   `update` can still move the resolved version forward with no ceiling at
+ *   all, but never below the floor.
  * - Dist-tags ("latest", "next", "canary") and anything else that isn't a
  *   single concrete semver (including ranges that are already ranges) pass
- *   through unchanged — you cannot caret a tag, and re-wrapping an existing
+ *   through unchanged — you cannot floor a tag, and re-wrapping an existing
  *   range would be wrong.
  * - Prereleases ("1.0.0-beta.1") are floored the same way as any other
- *   concrete version. `^1.0.0-beta.1` only matches later prereleases of the
- *   *same* major.minor.patch plus the eventual stable 1.0.0 release — it will
- *   not reach into a different prerelease line. That's inherent to how npm's
- *   semver treats prerelease tags (a range only admits a prerelease that
- *   shares [major,minor,patch] with one of its comparators), not something
- *   this function can or should work around. A prerelease override is
- *   already a narrow, deliberate pin, so that narrower floor is the correct
- *   behavior rather than a special case to avoid.
+ *   concrete version. `>=1.0.0-beta.1` has no upper bound at all, so it
+ *   matches every later stable release (1.9.4, 2.5.0, ...) exactly like a
+ *   normal `>=` floor would. The one narrowing that still applies is npm
+ *   semver's prerelease-tuple rule: a *prerelease* candidate (not a stable
+ *   release) only satisfies the range if it shares [major,minor,patch] with
+ *   a prerelease comparator already in the range — so `1.0.0-beta.5` and
+ *   `1.0.0-rc.1` satisfy it, but `2.0.0-alpha.1` does not. That's inherent
+ *   to how npm's semver treats prerelease tags, not something this function
+ *   can or should work around.
  */
 export function toFloorRange(version: string): string {
   const parsed = semver.valid(version, { loose: true });
-  return parsed ? `^${parsed}` : version;
+  return parsed ? `>=${parsed}` : version;
 }
 
 /**
- * Whether an installed version satisfies a target that applyOverrides wrote
- * as a floor. For concrete targets, "installed >= target" counts as success
- * — resolving higher than the floor is the point, not a mismatch. Falls back
- * to exact string equality when either side isn't a parseable concrete
- * version (dist-tag targets like "latest"), matching the pre-floor behavior.
+ * Whether an installed version satisfies the override value applyOverrides
+ * actually wrote for this target — `toFloorRange(targetVersion)` — rather
+ * than a plain "installed >= target" scalar comparison.
+ *
+ * This exists to verify the override actually took effect. A plain scalar
+ * comparison is too permissive for that job: a keyed pnpm override
+ * (`pkg@>=range`), a workspace catalog entry, or a parent package's own
+ * constraint can all steer the resolved version somewhere the override we
+ * wrote never sanctioned, and "installed >= target" would still read as
+ * success. Testing satisfaction against the exact range we wrote is what
+ * makes this a real verification rather than a rubber stamp — while still
+ * correctly treating "resolved higher than the floor" as success, since the
+ * range itself has no upper bound.
+ *
+ * Falls back to exact string equality when the written value isn't a
+ * parseable range (dist-tag targets like "latest"), matching the pre-floor
+ * behavior.
  */
-function meetsFloorTarget(installedVersion: string | undefined, targetVersion: string): boolean {
+function satisfiesWrittenOverride(installedVersion: string | undefined, targetVersion: string): boolean {
   if (!installedVersion) return false;
-  const installed = semver.valid(installedVersion, { loose: true });
-  const target = semver.valid(targetVersion, { loose: true });
-  if (installed && target) return semver.gte(installed, target);
+  const written = toFloorRange(targetVersion);
+  const range = semver.validRange(written, { loose: true });
+  if (range) return semver.satisfies(installedVersion, range, { loose: true });
   return installedVersion === targetVersion;
 }
 
@@ -70,7 +94,7 @@ export function removeOverrideConflicts(
 
     // An existing override/resolution is only a "conflict" with the incoming
     // direct-dep update if it would actually block that update from landing.
-    // Once applyOverrides writes floors ("^8.5.23") instead of exact pins,
+    // Once applyOverrides writes floors (">=8.5.23") instead of exact pins,
     // a plain string comparison against the new target ("8.5.26") is always
     // unequal — that would delete the very floor we just wrote, on every
     // subsequent direct-dep update. Test satisfaction instead: keep the
@@ -80,7 +104,11 @@ export function removeOverrideConflicts(
       const range = semver.validRange(pinned, { loose: true });
       const target = semver.valid(targetVersion, { loose: true });
       if (range && target) {
-        return !semver.satisfies(target, range, { loose: true, includePrerelease: true });
+        // No includePrerelease here: npm/pnpm evaluate override ranges
+        // without that flag when resolving, so this check has to match
+        // resolver semantics, not be more permissive than the actual
+        // resolution the range will ever be subjected to.
+        return !semver.satisfies(target, range, { loose: true });
       }
       // Either side isn't parseable semver (e.g. an npm "$pkg" alias or a git
       // URL) — fall back to the original strict string comparison so those
@@ -151,7 +179,7 @@ export function cleanStaleOverrides(
           const installed = JSON.parse(readFileSync(nmPath, 'utf-8')).version;
           // Only exact pins ("8.5.15") are ever candidates for staleness
           // removal here — deliberately, not incidentally. A range-valued
-          // override (the "^8.5.23" floors this file now writes) resolving
+          // override (the ">=8.5.23" floors this file now writes) resolving
           // to something newer than its base is the expected, desired
           // outcome, not staleness: the floor is still doing its job of
           // keeping the fleet off the vulnerable version. Removing it would
@@ -263,7 +291,16 @@ export async function applyOverrides(
           const p = join(cwd, 'node_modules', pkg.name, 'package.json');
           if (!existsSync(p)) return false;
           const installedVersion = JSON.parse(readFileSync(p, 'utf-8')).version;
-          return meetsFloorTarget(installedVersion, pkg.targetVersion);
+          // A version on disk that's identical to what was installed BEFORE
+          // this override ran is not evidence the install succeeded — it's
+          // evidence the install failed and left the pre-existing tree
+          // untouched. Without this guard, a failed install (registry 5xx,
+          // ERESOLVE, disk full) with a stale-but-already-satisfying copy in
+          // node_modules would get silently swallowed here, every package in
+          // this batch would report success, and the caller would go on to
+          // reconcile/audit a tree whose install never actually completed.
+          if (pkg.fromVersion && installedVersion === pkg.fromVersion) return false;
+          return satisfiesWrittenOverride(installedVersion, pkg.targetVersion);
         } catch { return false; }
       });
       if (!anyResolved) throw new Error(err.stderr || err.message || 'Install after override failed');
@@ -275,12 +312,18 @@ export async function applyOverrides(
         const installedPkgPath = join(cwd, 'node_modules', pkg.name, 'package.json');
         if (existsSync(installedPkgPath)) {
           const installedVersion = JSON.parse(readFileSync(installedPkgPath, 'utf-8')).version;
-          // With a caret floor written instead of an exact pin, resolving to
+          // With a `>=` floor written instead of an exact pin, resolving to
           // something newer than the target is success, not a mismatch — the
-          // floor did its job. Only warn when the resolved version doesn't
-          // meet the floor (or, for dist-tag targets, isn't an exact match,
-          // same as the pre-floor behavior).
-          if (!meetsFloorTarget(installedVersion, pkg.targetVersion)) {
+          // floor did its job. But this still has to be a real check, not a
+          // rubber stamp: compare against the range actually written
+          // (satisfiesWrittenOverride), not a bare "installed >= target"
+          // scalar, so a genuine mismatch (a keyed override, workspace
+          // catalog, or parent constraint steering resolution outside what
+          // we wrote) is still caught — see project issue #126, where a bare
+          // `>=` previously failed to move the resolved version under
+          // pnpm's node-linker=hoisted and this check is the only thing that
+          // detects that.
+          if (!satisfiesWrittenOverride(installedVersion, pkg.targetVersion)) {
             verifyWarning = ` ⚠ override written but ${pkg.name} resolved to ${installedVersion} — may need lockfile reset`;
             logger.warn('patches', 'override_version_mismatch', `Override for ${pkg.name}: expected ${pkg.targetVersion}, got ${installedVersion}`, {
               projectId,


### PR DESCRIPTION
A fleet audit found **29 of 32 projects** carrying exact postcss pins like `"postcss": "8.5.15"`. Eight were stuck on versions vulnerable to GHSA-r28c-9q8g-f849 — and an override *forces* a version, so no routine update could move them. **The override was what held them there.**

This file is where those pins came from: it wrote `pkg.targetVersion` verbatim, and its sibling logic assumed exact pins throughout.

## What changed

- **`applyOverrides`** emits a `>=` floor for concrete versions, matching the convention already used by this repo's own `esbuild`/`qs`/`hono`/`ws` overrides. Dist-tags, git URLs, `workspace:*` and npm aliases pass through untouched — a caret or floor can't be prefixed to those.
- **`removeOverrideConflicts`** uses semver satisfaction instead of string equality. Without this the tool would have deleted the floors it had just written (`"^8.5.23" !== "8.5.26"`), logged as `override_conflict_removed`.
- **`cleanStaleOverrides`** still skips range-valued overrides — deliberately, now documented. A working floor looks "stale" under an installed-is-newer rule, and removing it would strip security protection. Its exact-pin comparison moved from hand-rolled `parseInt` to semver.
- **Verification that actually runs.** The post-install check gated on root `node_modules/<pkg>`. These are transitive deps; under pnpm's default isolated linker they live in `.pnpm/`, so the check was a silent no-op on most of the fleet. It now scans the pnpm store, collects **every** copy, and flags a violation if *any* copy falls below the floor — the issue-#80 nested-copy class.
- **Honest reporting.** A `>=` floor resolves to `maxSatisfying`, so it can install a major beyond the target. `resolvedVersion` now records what actually landed alongside what was requested, and a major jump gets its own warning.

## Why `>=` and not a caret

Caret is **inert below 1.0.0**: `^0.0.3` expands to `>=0.0.3 <0.0.4-0` — one version, identical in effect to the exact pin this change exists to remove. `^0.5.1` caps at `<0.6.0`, and in `0.x` the minor is the breaking axis.

The trade is real: `>=` has no ceiling, so an override can admit a major. That's why the verification and resolved-version reporting above aren't optional extras — they're what makes an unbounded floor safe to run unattended.

## Review history

Four review rounds. Three findings are worth calling out because they'd each have been shipped silently:

1. **The verify check compared `installed >= target` rather than "satisfies the range we wrote"** — so a resolution *outside* the written range read as success.
2. **A `semver` throw on an unparseable version** was swallowed by a catch-all, producing `success: true` with no warning and no log, while the violating versions sat in a local variable. Strictly worse than the no-op it replaced.
3. **The store-aware lookup regressed the downgrade guard.** It returned the *highest* copy, so a vulnerable `8.4.31` beside a clean `8.5.30` read as "already past this fix" and the update was refused — leaving the vulnerable copy in place, on exactly the multi-copy isolated layouts this work targets. A downgrade guard needs the *lowest* copy. Both behaviours are now pinned by tests.

## Verification

336 → **382 tests**, 46 files. `tsc --noEmit` clean, `pnpm build` exit 0. `src/lib/updaters/` had no test file before this; it now has two. `semver` was previously only a transitive dependency — it's now properly declared, so this doesn't introduce the phantom-dep class HexOps itself detects.

## Follow-ups, deliberately not included

`overridePkgs.some(...)` batch semantics (one package resolving marks the batch recovered), `escalate/route.ts`'s duplicate hand-rolled version comparison, and wiring `resolvedVersion` into the patch-history UI and CSV export.