### PR TITLE
fix(process): Stop actually kills the dev server (#90)

### DIFF
--- a/src/app/api/projects/[id]/stop/route.ts
+++ b/src/app/api/projects/[id]/stop/route.ts
@@ -29,7 +29,7 @@ export async function POST(
       );
     }
 
-    const result = stopProject(id, project.port);
+    const result = await stopProject(id, project.port);
 
     if (!result.success) {
       return NextResponse.json(

--- a/src/lib/process-manager.test.ts
+++ b/src/lib/process-manager.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'events';
+import type { ChildProcess } from 'child_process';
 import type { ProjectConfig } from './types';
 
 // ---------------------------------------------------------------------------
@@ -29,6 +30,8 @@ import {
   runWithDevServerGuard,
   startProject,
   stopProject,
+  signalProcessGroup,
+  shutdownTrackedProcesses,
   type DevServerGuardDeps,
 } from './process-manager';
 
@@ -169,6 +172,25 @@ describe('runWithDevServerGuard (#109)', () => {
     expect(out.restarted).toBe(false);
     expect(out.restartError).toBe('port in use');
   });
+
+  it('orchestrate: aborts (blocked, operation never runs) when stop fails to actually free the server (#90 review finding I2)', async () => {
+    // Before #90, stopProject effectively always reported success, so a
+    // failed stop here was unreachable. Now it's real: running an install
+    // against a dev server that may still be live is exactly the hazard
+    // #109 exists to prevent.
+    const deps = makeDeps({
+      isRunning: () => true,
+      stop: vi.fn(async () => ({ success: false, error: 'still bound after SIGKILL' })),
+    });
+    const op = vi.fn(async () => 'should never run');
+    const out = await runWithDevServerGuard(makeProject(), op, {}, deps);
+    expect(out.blocked).toBe(true);
+    expect(out.ranOperation).toBe(false);
+    expect(out.result).toBeUndefined();
+    expect(op).not.toHaveBeenCalled();
+    expect(deps.start).not.toHaveBeenCalled(); // never tries to restart something it never actually stopped
+    expect(out.reason).toContain('still bound after SIGKILL');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -199,11 +221,26 @@ class FakeChildProcess extends EventEmitter {
 }
 
 describe('stopProject (#90 — verify before reporting success)', () => {
+  // Structural safety net (review finding C1): a prior revision left one
+  // test with no mock on process.kill at all — after vi.restoreAllMocks()
+  // ran in the previous test's afterEach, that test's process.kill(-pid,
+  // 'SIGTERM'/'SIGKILL') calls hit the REAL syscall against a fabricated
+  // pid, on a box that runs ~35 real dev servers. Spying here, before any
+  // test body runs, means no test in this describe block can ever reach the
+  // real syscall — even one that forgets to stub it itself. Individual
+  // tests only ever call `.mockImplementation`/`.mockReturnValue` on this
+  // shared spy, never `vi.spyOn(process, 'kill')` again.
+  function spyOnProcessKill() {
+    return vi.spyOn(process, 'kill').mockReturnValue(true);
+  }
+  let processKillSpy: ReturnType<typeof spyOnProcessKill>;
+
   beforeEach(() => {
     spawnMock.mockReset();
     execFileSyncMock.mockReset();
     checkPortMock.mockReset();
     addNotificationMock.mockReset();
+    processKillSpy = spyOnProcessKill();
   });
 
   afterEach(() => {
@@ -231,20 +268,26 @@ describe('stopProject (#90 — verify before reporting success)', () => {
   });
 
   it('signals the whole process group (-pid), not the bare pid', async () => {
-    trackProject('group-signal', 4242);
+    const fake = trackProject('group-signal', 4242);
     checkPortMock.mockResolvedValue(false); // port already free once signalled
-    const killSpy = vi.spyOn(process, 'kill').mockReturnValue(true);
+    processKillSpy.mockImplementation((_pid, signal) => {
+      if (signal === 'SIGTERM') fake.exitCode = 0; // simulate the real process actually exiting
+      return true;
+    });
 
     const result = await stopProject('group-signal', 3001);
 
     expect(result.success).toBe(true);
-    expect(killSpy).toHaveBeenCalledWith(-4242, 'SIGTERM');
+    expect(processKillSpy).toHaveBeenCalledWith(-4242, 'SIGTERM');
   });
 
   it('returns success once the port is actually released after SIGTERM', async () => {
-    trackProject('freed', 7777);
+    const fake = trackProject('freed', 7777);
     checkPortMock.mockResolvedValue(false);
-    vi.spyOn(process, 'kill').mockReturnValue(true);
+    processKillSpy.mockImplementation(() => {
+      fake.exitCode = 0;
+      return true;
+    });
 
     const result = await stopProject('freed', 3001);
 
@@ -253,11 +296,15 @@ describe('stopProject (#90 — verify before reporting success)', () => {
 
   it('escalates to SIGKILL when the port is still bound after SIGTERM', async () => {
     vi.useFakeTimers();
-    trackProject('escalate', 5555);
+    const fake = trackProject('escalate', 5555);
     let bound = true;
     checkPortMock.mockImplementation(async () => bound);
-    const killSpy = vi.spyOn(process, 'kill').mockImplementation((_pid, signal) => {
-      if (signal === 'SIGKILL') bound = false; // SIGKILL is what actually frees it
+    processKillSpy.mockImplementation((_pid, signal) => {
+      if (signal === 'SIGKILL') {
+        bound = false; // SIGKILL is what actually frees it
+        fake.exitCode = null;
+        fake.signalCode = 'SIGKILL';
+      }
       return true;
     });
 
@@ -265,8 +312,8 @@ describe('stopProject (#90 — verify before reporting success)', () => {
     await vi.advanceTimersByTimeAsync(10_000);
     const result = await resultPromise;
 
-    expect(killSpy).toHaveBeenCalledWith(-5555, 'SIGTERM');
-    expect(killSpy).toHaveBeenCalledWith(-5555, 'SIGKILL');
+    expect(processKillSpy).toHaveBeenCalledWith(-5555, 'SIGTERM');
+    expect(processKillSpy).toHaveBeenCalledWith(-5555, 'SIGKILL');
     expect(result.success).toBe(true);
   });
 
@@ -275,6 +322,9 @@ describe('stopProject (#90 — verify before reporting success)', () => {
     trackProject('never-frees', 6666);
     checkPortMock.mockResolvedValue(true); // nothing ever frees it
     execFileSyncMock.mockReturnValue(''); // ss finds nothing either
+    // processKillSpy keeps its safe default from beforeEach (returns true,
+    // no side effects) — this test intentionally does not override it, to
+    // prove the describe-level default alone is what keeps it safe.
 
     const resultPromise = stopProject('never-frees', 3001);
     await vi.advanceTimersByTimeAsync(15_000);
@@ -282,26 +332,56 @@ describe('stopProject (#90 — verify before reporting success)', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toBeTruthy();
+    expect(processKillSpy).toHaveBeenCalledWith(-6666, 'SIGTERM');
+    expect(processKillSpy).toHaveBeenCalledWith(-6666, 'SIGKILL');
   });
 
   it('treats ESRCH from the kill syscall as already-stopped, not a failure', async () => {
     trackProject('esrch', 8888);
     checkPortMock.mockResolvedValue(false); // consistent with the process already being gone
     const esrch = Object.assign(new Error('kill ESRCH'), { code: 'ESRCH' });
-    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+    processKillSpy.mockImplementation(() => {
       throw esrch;
     });
 
     const result = await stopProject('esrch', 3001);
 
     expect(result.success).toBe(true);
-    expect(killSpy).toHaveBeenCalledWith(-8888, 'SIGTERM');
+    expect(processKillSpy).toHaveBeenCalledWith(-8888, 'SIGTERM');
+  });
+
+  it('an EPERM on the tracked group kill does not crash stopProject — it logs and falls through to the port-based fallback', async () => {
+    // Review finding M4: ESRCH-swallowing was tested, but the "most
+    // dangerous" branch — a real signalling failure like EPERM — had no
+    // coverage at the stopProject level at all.
+    vi.useFakeTimers();
+    trackProject('eperm-fallback', 4444);
+    let bound = true;
+    checkPortMock.mockImplementation(async () => bound);
+    const eperm = Object.assign(new Error('kill EPERM'), { code: 'EPERM' });
+    processKillSpy.mockImplementation(() => {
+      throw eperm;
+    });
+    execFileSyncMock.mockImplementation((cmd: string) => {
+      if (cmd === 'ss') return 'LISTEN 0 511 *:3001 *:* users:(("node",pid=4445,fd=19))';
+      if (cmd === 'kill') {
+        bound = false;
+        return '';
+      }
+      return '';
+    });
+
+    const resultPromise = stopProject('eperm-fallback', 3001);
+    await vi.advanceTimersByTimeAsync(10_000);
+    const result = await resultPromise;
+
+    expect(result.success).toBe(true);
+    expect(execFileSyncMock).toHaveBeenCalledWith('kill', ['-9', '4445']);
   });
 
   it('runs the port-based fallback when there is no tracked entry at all (e.g. an orphaned server)', async () => {
     let bound = true;
     checkPortMock.mockImplementation(async () => bound);
-    const killSpy = vi.spyOn(process, 'kill');
     execFileSyncMock.mockImplementation((cmd: string) => {
       if (cmd === 'ss') return 'LISTEN 0 511 *:3001 *:* users:(("node",pid=9999,fd=19))';
       if (cmd === 'kill') {
@@ -316,7 +396,7 @@ describe('stopProject (#90 — verify before reporting success)', () => {
     expect(result.success).toBe(true);
     expect(execFileSyncMock).toHaveBeenCalledWith('ss', expect.arrayContaining(['-tlnp']), expect.anything());
     expect(execFileSyncMock).toHaveBeenCalledWith('kill', ['-9', '9999']);
-    expect(killSpy).not.toHaveBeenCalled(); // no tracked group to signal — this is the port-only path
+    expect(processKillSpy).not.toHaveBeenCalled(); // no tracked group to signal — this is the port-only path
   });
 
   it('reports failure (not success) when the port-based fallback finds nothing and the port stays bound', async () => {
@@ -330,6 +410,22 @@ describe('stopProject (#90 — verify before reporting success)', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toBeTruthy();
+  });
+
+  it('refuses to kill hexops itself (or its parent) even if ss lists it on the port (review finding I1)', async () => {
+    vi.useFakeTimers();
+    checkPortMock.mockResolvedValue(true); // stays "bound" from hexops' own listener's point of view
+    execFileSyncMock.mockImplementation((cmd: string) => {
+      if (cmd === 'ss') return `LISTEN 0 511 *:3001 *:* users:(("node",pid=${process.pid},fd=19))`;
+      return '';
+    });
+
+    const resultPromise = stopProject('self-guard', 3001);
+    await vi.advanceTimersByTimeAsync(5_000);
+    const result = await resultPromise;
+
+    expect(result.success).toBe(false);
+    expect(execFileSyncMock).not.toHaveBeenCalledWith('kill', expect.anything());
   });
 
   it('an untracked/orphan stop does not poison crash detection for a later real process with the same id', async () => {
@@ -351,5 +447,119 @@ describe('stopProject (#90 — verify before reporting success)', () => {
       severity: 'error',
       projectId: 'orphan-then-real',
     });
+  });
+
+  it('marks intentional even when the tracked child already looks exited but its close is still pending (review finding C2 regression)', async () => {
+    // With shell: true, the direct child (sh) can look exited while a
+    // grandchild that inherited its stdio pipes is still holding them open
+    // — and, in the real #90 shape, still holding the port. Node defers
+    // 'close' until those pipes finish draining. An earlier revision of this
+    // fix only marked stoppingProjects when the tracked entry was "live"
+    // (exitCode === null), so this exact routine case fell through
+    // unmarked: the pending close later fired with intentional=false — a
+    // false "crashed" notification, and with restartOnCrash on, hexops
+    // would relaunch the server the user had just deliberately stopped.
+    const fake = trackProject('exited-but-pending-close', 3333);
+    fake.exitCode = 1; // direct child already looks exited...
+
+    let bound = true;
+    checkPortMock.mockImplementation(async () => bound);
+    execFileSyncMock.mockImplementation((cmd: string) => {
+      if (cmd === 'ss') return 'LISTEN 0 511 *:3001 *:* users:(("node",pid=3334,fd=19))';
+      if (cmd === 'kill') {
+        bound = false;
+        return '';
+      }
+      return '';
+    });
+
+    const stopResult = await stopProject('exited-but-pending-close', 3001);
+    expect(stopResult.success).toBe(true);
+    // isLive was false, so the tracked signalling branch never ran — this
+    // was resolved entirely by the port-based fallback, exactly as it would
+    // be in the real grandchild-holds-the-port shape.
+    expect(processKillSpy).not.toHaveBeenCalled();
+
+    // ...and now its 'close' fires late, as it would for real once the
+    // grandchild's pipes finally drain. It must be read as intentional.
+    addNotificationMock.mockClear();
+    fake.emit('close', 1, null);
+    expect(addNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it('port released but the process itself has not exited yet: sends a defensive final SIGKILL rather than trusting the port alone (review finding M3)', async () => {
+    const fake = trackProject('hung-after-close', 5678);
+    checkPortMock.mockResolvedValue(false); // socket already released...
+    // ...but the process itself never actually exits (fake.exitCode stays
+    // null throughout) — e.g. it closed its listener but hung.
+    processKillSpy.mockReturnValue(true);
+
+    const result = await stopProject('hung-after-close', 3001);
+
+    expect(result.success).toBe(true); // #90's contract (port released) is still honored
+    expect(processKillSpy).toHaveBeenCalledWith(-5678, 'SIGTERM');
+    // A second, defensive SIGKILL must have been sent once the grace window
+    // for the process to actually exit elapsed without it doing so.
+    expect(processKillSpy).toHaveBeenCalledWith(-5678, 'SIGKILL');
+  });
+});
+
+describe('signalProcessGroup (#90 — review finding M4: ESRCH vs EPERM must be genuinely distinguished)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('swallows ESRCH (group already gone) rather than throwing', () => {
+    const fake = new FakeChildProcess(1111);
+    const esrch = Object.assign(new Error('kill ESRCH'), { code: 'ESRCH' });
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw esrch;
+    });
+
+    expect(() => signalProcessGroup(fake as unknown as ChildProcess, 'SIGTERM')).not.toThrow();
+    expect(killSpy).toHaveBeenCalledWith(-1111, 'SIGTERM');
+  });
+
+  it('rethrows EPERM (permission denied) rather than swallowing it', () => {
+    const fake = new FakeChildProcess(2222);
+    const eperm = Object.assign(new Error('kill EPERM'), { code: 'EPERM' });
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw eperm;
+    });
+
+    expect(() => signalProcessGroup(fake as unknown as ChildProcess, 'SIGTERM')).toThrow('kill EPERM');
+    expect(killSpy).toHaveBeenCalledWith(-2222, 'SIGTERM');
+  });
+});
+
+describe('shutdownTrackedProcesses (#90 — review finding I3: detached children need explicit cleanup)', () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('signals the process group of every currently tracked child', () => {
+    const killSpy = vi.spyOn(process, 'kill').mockReturnValue(true);
+
+    const fakeA = new FakeChildProcess(6001);
+    spawnMock.mockReturnValueOnce(fakeA);
+    expect(startProject(makeProject({ id: 'shutdown-a', port: 4101 })).success).toBe(true);
+
+    const fakeB = new FakeChildProcess(6002);
+    spawnMock.mockReturnValueOnce(fakeB);
+    expect(startProject(makeProject({ id: 'shutdown-b', port: 4102 })).success).toBe(true);
+
+    shutdownTrackedProcesses('SIGTERM');
+
+    expect(killSpy).toHaveBeenCalledWith(-6001, 'SIGTERM');
+    expect(killSpy).toHaveBeenCalledWith(-6002, 'SIGTERM');
+
+    // Tidy up module state for later tests: let both children's 'close'
+    // fire as a clean, non-crash exit.
+    fakeA.emit('close', 0, null);
+    fakeB.emit('close', 0, null);
   });
 });

--- a/src/lib/process-manager.test.ts
+++ b/src/lib/process-manager.test.ts
@@ -1,12 +1,36 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+import type { ProjectConfig } from './types';
+
+// ---------------------------------------------------------------------------
+// #90 — mocks for the real-process-touching parts of stopProject/startProject.
+// vi.mock factories are hoisted above all imports by vitest's transform, so
+// they must close over vi.hoisted() values rather than plain module consts.
+// ---------------------------------------------------------------------------
+const { spawnMock, execFileSyncMock, checkPortMock, addNotificationMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+  execFileSyncMock: vi.fn(),
+  checkPortMock: vi.fn(),
+  addNotificationMock: vi.fn(),
+}));
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return { ...actual, spawn: spawnMock, execFileSync: execFileSyncMock };
+});
+
+vi.mock('./port-checker', () => ({ checkPort: checkPortMock }));
+vi.mock('./notifications', () => ({ addNotification: addNotificationMock }));
+
 import {
   withoutInheritedBundlerEnv,
   decideDevServerGuard,
   isHexopsSelf,
   runWithDevServerGuard,
+  startProject,
+  stopProject,
   type DevServerGuardDeps,
 } from './process-manager';
-import type { ProjectConfig } from './types';
 
 function makeProject(overrides: Partial<ProjectConfig> = {}): ProjectConfig {
   return {
@@ -71,7 +95,7 @@ describe('runWithDevServerGuard (#109)', () => {
       isSelf: () => false,
       isRunning: () => false,
       getMode: () => 'dev',
-      stop: vi.fn(() => ({ success: true })),
+      stop: vi.fn(async () => ({ success: true })),
       start: vi.fn(() => ({ success: true })),
       clearBuildDir: vi.fn(),
       ...overrides,
@@ -107,7 +131,7 @@ describe('runWithDevServerGuard (#109)', () => {
     const deps = makeDeps({
       isRunning: () => true,
       getMode: () => 'prod',
-      stop: vi.fn(() => { calls.push('stop'); return { success: true }; }),
+      stop: vi.fn(async () => { calls.push('stop'); return { success: true }; }),
       start: vi.fn((_p, mode) => { calls.push(`start:${mode}`); return { success: true }; }),
       clearBuildDir: vi.fn(() => { calls.push('clear'); }),
     });
@@ -144,5 +168,188 @@ describe('runWithDevServerGuard (#109)', () => {
     expect(out.result).toBe('ok');
     expect(out.restarted).toBe(false);
     expect(out.restartError).toBe('port in use');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #90 — Stop returns success while next-server keeps running
+//
+// child_process.spawn/execFileSync and port-checker.checkPort are mocked
+// (see top of file); no real dev server or port is ever bound here. A fake
+// ChildProcess-like EventEmitter stands in for the tracked child so
+// startProject's real bookkeeping (activeProcesses, close handling) runs
+// unmodified.
+// ---------------------------------------------------------------------------
+
+class FakeChildProcess extends EventEmitter {
+  pid: number | undefined;
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  killed = false;
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill = vi.fn((_signal?: NodeJS.Signals | number) => {
+    this.killed = true;
+    return true;
+  });
+  constructor(pid: number) {
+    super();
+    this.pid = pid;
+  }
+}
+
+describe('stopProject (#90 — verify before reporting success)', () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+    execFileSyncMock.mockReset();
+    checkPortMock.mockReset();
+    addNotificationMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  /** Spawn a project via the real startProject path with a fake child, so it lands in activeProcesses. */
+  function trackProject(id: string, pid: number, port = 3001): FakeChildProcess {
+    const fake = new FakeChildProcess(pid);
+    spawnMock.mockReturnValueOnce(fake);
+    const result = startProject(makeProject({ id, port }));
+    expect(result.success).toBe(true);
+    return fake;
+  }
+
+  it('spawns with detached: true so the whole process tree can be signalled', () => {
+    const fake = new FakeChildProcess(1234);
+    spawnMock.mockReturnValueOnce(fake);
+    const result = startProject(makeProject({ id: 'spawn-opts' }));
+    expect(result.success).toBe(true);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const options = spawnMock.mock.calls[0][2] as { detached?: boolean };
+    expect(options.detached).toBe(true);
+  });
+
+  it('signals the whole process group (-pid), not the bare pid', async () => {
+    trackProject('group-signal', 4242);
+    checkPortMock.mockResolvedValue(false); // port already free once signalled
+    const killSpy = vi.spyOn(process, 'kill').mockReturnValue(true);
+
+    const result = await stopProject('group-signal', 3001);
+
+    expect(result.success).toBe(true);
+    expect(killSpy).toHaveBeenCalledWith(-4242, 'SIGTERM');
+  });
+
+  it('returns success once the port is actually released after SIGTERM', async () => {
+    trackProject('freed', 7777);
+    checkPortMock.mockResolvedValue(false);
+    vi.spyOn(process, 'kill').mockReturnValue(true);
+
+    const result = await stopProject('freed', 3001);
+
+    expect(result).toEqual({ success: true });
+  });
+
+  it('escalates to SIGKILL when the port is still bound after SIGTERM', async () => {
+    vi.useFakeTimers();
+    trackProject('escalate', 5555);
+    let bound = true;
+    checkPortMock.mockImplementation(async () => bound);
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation((_pid, signal) => {
+      if (signal === 'SIGKILL') bound = false; // SIGKILL is what actually frees it
+      return true;
+    });
+
+    const resultPromise = stopProject('escalate', 3001);
+    await vi.advanceTimersByTimeAsync(10_000);
+    const result = await resultPromise;
+
+    expect(killSpy).toHaveBeenCalledWith(-5555, 'SIGTERM');
+    expect(killSpy).toHaveBeenCalledWith(-5555, 'SIGKILL');
+    expect(result.success).toBe(true);
+  });
+
+  it('returns success: false with an error when the port is still bound after SIGTERM and SIGKILL', async () => {
+    vi.useFakeTimers();
+    trackProject('never-frees', 6666);
+    checkPortMock.mockResolvedValue(true); // nothing ever frees it
+    execFileSyncMock.mockReturnValue(''); // ss finds nothing either
+
+    const resultPromise = stopProject('never-frees', 3001);
+    await vi.advanceTimersByTimeAsync(15_000);
+    const result = await resultPromise;
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  it('treats ESRCH from the kill syscall as already-stopped, not a failure', async () => {
+    trackProject('esrch', 8888);
+    checkPortMock.mockResolvedValue(false); // consistent with the process already being gone
+    const esrch = Object.assign(new Error('kill ESRCH'), { code: 'ESRCH' });
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw esrch;
+    });
+
+    const result = await stopProject('esrch', 3001);
+
+    expect(result.success).toBe(true);
+    expect(killSpy).toHaveBeenCalledWith(-8888, 'SIGTERM');
+  });
+
+  it('runs the port-based fallback when there is no tracked entry at all (e.g. an orphaned server)', async () => {
+    let bound = true;
+    checkPortMock.mockImplementation(async () => bound);
+    const killSpy = vi.spyOn(process, 'kill');
+    execFileSyncMock.mockImplementation((cmd: string) => {
+      if (cmd === 'ss') return 'LISTEN 0 511 *:3001 *:* users:(("node",pid=9999,fd=19))';
+      if (cmd === 'kill') {
+        bound = false;
+        return '';
+      }
+      return '';
+    });
+
+    const result = await stopProject('never-tracked', 3001);
+
+    expect(result.success).toBe(true);
+    expect(execFileSyncMock).toHaveBeenCalledWith('ss', expect.arrayContaining(['-tlnp']), expect.anything());
+    expect(execFileSyncMock).toHaveBeenCalledWith('kill', ['-9', '9999']);
+    expect(killSpy).not.toHaveBeenCalled(); // no tracked group to signal — this is the port-only path
+  });
+
+  it('reports failure (not success) when the port-based fallback finds nothing and the port stays bound', async () => {
+    checkPortMock.mockResolvedValue(true);
+    execFileSyncMock.mockImplementation((cmd: string) => {
+      if (cmd === 'ss') return ''; // nothing found
+      return '';
+    });
+
+    const result = await stopProject('untracked-stuck', 3001);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  it('an untracked/orphan stop does not poison crash detection for a later real process with the same id', async () => {
+    // Reproduces the exact #90 incident: an orphaned server with no tracked
+    // entry gets stopped via the port-based fallback. Before the fix,
+    // stoppingProjects was marked unconditionally and never cleaned up when
+    // there was no ChildProcess to fire a 'close' event — silently disabling
+    // crash notifications for this projectId forever.
+    checkPortMock.mockResolvedValue(false); // nothing listening; fallback no-ops to success
+    const orphanStop = await stopProject('orphan-then-real', 3001);
+    expect(orphanStop.success).toBe(true);
+    expect(addNotificationMock).not.toHaveBeenCalled();
+
+    const fake = trackProject('orphan-then-real', 2222);
+    fake.emit('close', 1, null); // a genuine crash: non-zero exit, no signal, no stop in flight
+
+    expect(addNotificationMock).toHaveBeenCalledTimes(1);
+    expect(addNotificationMock.mock.calls[0][0]).toMatchObject({
+      severity: 'error',
+      projectId: 'orphan-then-real',
+    });
   });
 });

--- a/src/lib/process-manager.ts
+++ b/src/lib/process-manager.ts
@@ -215,7 +215,15 @@ export function startProject(
     child.on('close', (code, signal) => {
       const intentional = stoppingProjects.has(project.id);
       stoppingProjects.delete(project.id);
-      activeProcesses.delete(project.id);
+      // Guard by identity (review finding M1): activeProcesses can already
+      // hold a *different*, newer child for this projectId by the time a
+      // stale 'close' fires (e.g. this child was killed via the port-based
+      // fallback rather than through its own ChildProcess handle, and a
+      // fresh start happened before the OS finished reaping it). Deleting
+      // unconditionally would untrack the replacement out from under it.
+      if (activeProcesses.get(project.id)?.process === child) {
+        activeProcesses.delete(project.id);
+      }
 
       const isCrash = !intentional && code !== 0;
 
@@ -294,13 +302,25 @@ export function startProject(
 const STOP_SIGTERM_TIMEOUT_MS = 4000;
 const STOP_SIGKILL_TIMEOUT_MS = 1500;
 const STOP_POLL_INTERVAL_MS = 150;
-const STOP_PORT_CHECK_TIMEOUT_MS = 300;
+// A grace period for the *process* (not the port) to actually exit once its
+// port is confirmed free — see waitUntilProcessExited / M3 below.
+const STOP_PROCESS_EXIT_GRACE_MS = 500;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/** Poll checkPort until it reports the port free, or timeoutMs elapses. */
+/**
+ * Poll checkPort until it reports the port free, or timeoutMs elapses.
+ *
+ * Deliberately does NOT pass a shortened timeout to checkPort (review
+ * finding M2): checkPort resolves `false` — "free" — on its own connect
+ * *timeout*, indistinguishable from a genuine connection refusal. A short
+ * per-attempt timeout here would let a slow-but-still-bound port read as
+ * released, which is a false-success path in exactly the function whose job
+ * is eliminating false successes. checkPort's 1000ms default is kept as-is;
+ * only the interval between polls is tuned.
+ */
 async function waitUntilPortFree(
   port: number,
   timeoutMs: number,
@@ -308,10 +328,26 @@ async function waitUntilPortFree(
 ): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   // Always check at least once, even for a zero-length budget.
-  if (!(await checkPort(port, STOP_PORT_CHECK_TIMEOUT_MS))) return true;
+  if (!(await checkPort(port))) return true;
   while (Date.now() < deadline) {
     await sleep(pollIntervalMs);
-    if (!(await checkPort(port, STOP_PORT_CHECK_TIMEOUT_MS))) return true;
+    if (!(await checkPort(port))) return true;
+  }
+  return false;
+}
+
+/** Poll a tracked child's exitCode/signalCode until it has actually exited, or timeoutMs elapses. */
+async function waitUntilProcessExited(
+  child: ChildProcess,
+  timeoutMs: number,
+  pollIntervalMs: number = STOP_POLL_INTERVAL_MS
+): Promise<boolean> {
+  const exited = () => child.exitCode !== null || child.signalCode !== null;
+  const deadline = Date.now() + timeoutMs;
+  if (exited()) return true;
+  while (Date.now() < deadline) {
+    await sleep(pollIntervalMs);
+    if (exited()) return true;
   }
   return false;
 }
@@ -330,8 +366,13 @@ function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
  * A group/process that is already gone answers with ESRCH — that is treated
  * as "already stopped," not an error, and is swallowed here. Any other
  * failure (e.g. EPERM) is rethrown for the caller to log and route around.
+ *
+ * Exported (only) so unit tests can pin the ESRCH-vs-EPERM branches directly
+ * rather than through stopProject's mocked-checkPort flow, where both
+ * branches are observably identical (review finding M4). Not part of the
+ * intended public API of this module.
  */
-function signalProcessGroup(child: ChildProcess, signal: NodeJS.Signals): void {
+export function signalProcessGroup(child: ChildProcess, signal: NodeJS.Signals): void {
   const pid = child.pid;
   if (!pid) return;
 
@@ -358,7 +399,7 @@ function signalProcessGroup(child: ChildProcess, signal: NodeJS.Signals): void {
  * still didn't free the port.
  */
 async function stopByPort(projectId: string, port: number): Promise<{ success: boolean; error?: string }> {
-  if (!(await checkPort(port, STOP_PORT_CHECK_TIMEOUT_MS))) {
+  if (!(await checkPort(port))) {
     return { success: true };
   }
 
@@ -378,14 +419,34 @@ async function stopByPort(projectId: string, port: number): Promise<{ success: b
       // ss may fail, which is fine
     }
 
+    let killedAny = false;
     for (const pid of pids) {
       // Validate pid is numeric before using
-      if (/^\d+$/.test(pid)) {
-        try {
-          execFileSync('kill', ['-9', pid]);
-        } catch {
-          // Ignore errors (process may have already exited)
-        }
+      if (!/^\d+$/.test(pid)) continue;
+
+      const numericPid = Number(pid);
+      // Ownership guard (review finding I1): this fallback previously ran
+      // only on a thrown error and never actually killed anything, so it
+      // never had a chance to hit hexops itself. Now that it's a real path
+      // reachable from a *tracked* stop whose group died but whose port is
+      // held by something else, refuse to touch hexops' own pid or its
+      // parent — a project misconfigured onto hexops' own port must not be
+      // able to make Stop kill hexops.
+      if (numericPid === process.pid || numericPid === process.ppid) {
+        addLogEntry(
+          projectId,
+          'stderr',
+          `[SYS] Refusing to kill pid ${pid} on port ${port} — it is hexops itself (or its parent)`
+        );
+        continue;
+      }
+
+      addLogEntry(projectId, 'stdout', `[SYS] Killing pid ${pid} found listening on port ${port}`);
+      try {
+        execFileSync('kill', ['-9', pid]);
+        killedAny = true;
+      } catch {
+        // Ignore errors (process may have already exited)
       }
     }
 
@@ -397,9 +458,9 @@ async function stopByPort(projectId: string, port: number): Promise<{ success: b
 
     return {
       success: false,
-      error: pids.length > 0
+      error: killedAny
         ? `Sent SIGKILL to pid(s) ${pids.join(', ')} on port ${port}, but the port is still bound`
-        : `No process found on port ${port} via ss, but the port is still bound`,
+        : `No killable process found on port ${port} via ss, but the port is still bound`,
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
@@ -417,16 +478,26 @@ export async function stopProject(projectId: string, port: number): Promise<{ su
   const isLive = entry != null && entry.process.pid != null
     && entry.process.exitCode === null && entry.process.signalCode === null;
 
-  if (entry && isLive) {
-    // Mark this projectId as an intentional stop *before* signalling, since
-    // the child's 'close' handler can fire at any point during the awaits
-    // below and needs to see this to avoid treating it as a crash. Only set
-    // when there's a live tracked process — a 'close' event will eventually
-    // clean this back up. (Setting it unconditionally, including for the
-    // port-only fallback below, would leak forever for a projectId with no
-    // tracked entry, silently disabling crash detection on a later start.)
+  // Mark this projectId as an intentional stop whenever there's a tracked
+  // ChildProcess at all — not only a "live" one (review finding C2, fixing a
+  // regression from an earlier revision of this patch). A tracked child
+  // *always* has a 'close' event still coming, even if exitCode/signalCode
+  // already look set: with shell: true, Node holds 'close' until every
+  // stdio pipe finishes draining, and a grandchild that inherited those
+  // pipes while still holding the real port (exactly the #90 shape) can
+  // keep 'close' pending well after the direct child looks exited. If we
+  // only mark intentional for the "live" case, that pending close later
+  // fires with intentional=false — a false "crashed" notification, and if
+  // restartOnCrash is on, hexops relaunches the server the user just
+  // stopped. An entry with genuinely no ChildProcess (nothing tracked at
+  // all) has no 'close' coming, ever, for this stop — that's the leak this
+  // guard was originally added to avoid, and remains avoided since `entry`
+  // is undefined in that case.
+  if (entry) {
     stoppingProjects.add(projectId);
+  }
 
+  if (entry && isLive) {
     try {
       signalProcessGroup(entry.process, 'SIGTERM');
     } catch (error) {
@@ -448,6 +519,27 @@ export async function stopProject(projectId: string, port: number): Promise<{ su
     }
 
     if (portFreed) {
+      // Success is port-gated above, but we're holding a live ChildProcess
+      // handle — use it (review finding M3). A server that closes its
+      // listener and then hangs (rather than actually exiting) would read
+      // as "free" by port alone while the group is still alive. Give it a
+      // short grace window to actually exit; if it hasn't, finish the job
+      // with one more defensive SIGKILL rather than silently deleting the
+      // tracking entry out from under a process that's still running.
+      const exited = await waitUntilProcessExited(entry.process, STOP_PROCESS_EXIT_GRACE_MS);
+      if (!exited) {
+        addLogEntry(
+          projectId,
+          'stderr',
+          '[SYS] Port released but the process had not exited — sending a final defensive SIGKILL'
+        );
+        try {
+          signalProcessGroup(entry.process, 'SIGKILL');
+        } catch {
+          // best-effort; we've already committed to reporting success on
+          // the port contract below
+        }
+      }
       activeProcesses.delete(projectId);
       addLogEntry(projectId, 'stdout', '[SYS] Process stopped');
       return { success: true };
@@ -469,6 +561,56 @@ export async function stopProject(projectId: string, port: number): Promise<{ su
   }
   return fallback;
 }
+
+/**
+ * Signal every currently-tracked child's process group (review finding I3).
+ *
+ * Before #90, tracked children stayed in hexops's own foreground process
+ * group and session (`detached: false`), so a terminal Ctrl-C (SIGINT to the
+ * foreground group) or terminal close (SIGHUP to the session) reaped them
+ * along with hexops itself — no explicit cleanup code was needed. `detached:
+ * true` (the #90 fix) calls `setsid()`, which deliberately severs each
+ * tracked child into its own group *and* session so stopProject can signal
+ * it precisely — but that same severing means those signals no longer reach
+ * tracked children automatically. Without this, every tracked dev server
+ * would become an orphan the instant hexops exits via Ctrl-C, not just on a
+ * hexops crash. Exported so tests can call it directly without sending a
+ * real OS signal.
+ */
+export function shutdownTrackedProcesses(signal: NodeJS.Signals = 'SIGTERM'): void {
+  for (const [projectId, entry] of activeProcesses) {
+    try {
+      signalProcessGroup(entry.process, signal);
+      addLogEntry(projectId, 'stdout', `[SYS] hexops is shutting down (${signal}) — signalled tracked process group`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      addLogEntry(projectId, 'stderr', `[SYS] Failed to signal process group during shutdown: ${message}`);
+    }
+  }
+}
+
+// Wire shutdownTrackedProcesses to real OS signals, once, outside test runs.
+// Guarded by VITEST/NODE_ENV=test (both are how this module is imported
+// under the unit suite) so importing process-manager.ts in a test file never
+// installs a real process.on('SIGTERM', ...) handler that could call
+// process.exit() on a test worker — vitest's own pool workers are routinely
+// sent SIGTERM for perfectly normal lifecycle reasons (timeouts, --watch
+// restarts, teardown), and intercepting that would be its own hazard.
+const isTestEnv = process.env.VITEST === 'true' || process.env.NODE_ENV === 'test';
+let shutdownHandlersRegistered = false;
+function registerShutdownHandlers(): void {
+  if (shutdownHandlersRegistered || isTestEnv || process.platform === 'win32') return;
+  shutdownHandlersRegistered = true;
+  process.on('SIGINT', () => {
+    shutdownTrackedProcesses('SIGINT');
+    process.exit(130);
+  });
+  process.on('SIGTERM', () => {
+    shutdownTrackedProcesses('SIGTERM');
+    process.exit(143);
+  });
+}
+registerShutdownHandlers();
 
 // Strip ANSI escape codes for clean display
 function stripAnsi(str: string): string {
@@ -670,6 +812,24 @@ export async function runWithDevServerGuard<T>(
   // orchestrate: capture the mode before stopping, restore in finally
   const mode = deps.getMode(project.id);
   const stopResult = await deps.stop(project.id, project.port);
+
+  // Review finding I2: before #90, stopProject effectively always reported
+  // success (that was the bug), so a failed stop here was unreachable and
+  // this branch never mattered. Now it's real: running `operation` (an
+  // install) against a dev server that is still actually alive is exactly
+  // the hazard #109 exists to prevent (Turbopack loses node_modules/next
+  // mid-reinstall and dies). Abort before running it.
+  if (!stopResult.success) {
+    return {
+      decision: decision.action,
+      reason: `Could not stop the dev server before applying: ${stopResult.error ?? 'unknown error'}. Refusing to run the operation against a server that may still be live.`,
+      blocked: true,
+      ranOperation: false,
+      stopped: false,
+      restarted: false,
+    };
+  }
+
   let result: T | undefined;
   let restarted = false;
   let restartError: string | undefined;

--- a/src/lib/process-manager.ts
+++ b/src/lib/process-manager.ts
@@ -5,6 +5,7 @@ import type { ProjectConfig, LogEntry } from './types';
 import { logger } from './logger';
 import { getProjectSettings } from './settings';
 import { addNotification } from './notifications';
+import { checkPort } from './port-checker';
 
 interface ProcessEntry {
   process: ChildProcess;
@@ -165,7 +166,22 @@ export function startProject(
     const child = spawn(cmd, args, {
       cwd: project.path,
       shell: projectSettings.shell ?? true,
-      detached: false,
+      // detached: true makes the child its own process-group leader (POSIX
+      // setsid). With shell: true the tracked pid is the `sh -c "<cmd>"`
+      // wrapper, not the real dev server it execs/forks — a plain SIGTERM to
+      // that pid only reaches `sh`, which does not forward signals to its
+      // child, so the real process (e.g. next-server) survives and keeps the
+      // port bound (#90). Putting the child in its own group lets stopProject
+      // signal the whole group via `process.kill(-pid, ...)`.
+      //
+      // Consequence: a detached child is no longer auto-killed when hexops's
+      // own process exits. That's accepted here — these are long-lived dev
+      // servers hexops is meant to manage independently of its own restarts,
+      // and the previous shell-wrapper setup was *already* orphaning the
+      // real process in practice (this bug is proof of that). We deliberately
+      // do NOT call child.unref() — stdout/stderr must keep flowing into the
+      // log buffer for as long as hexops is up to observe them.
+      detached: true,
       env: {
         ...withoutInheritedBundlerEnv(process.env),
         ...projectFileEnv,
@@ -271,36 +287,89 @@ export function startProject(
   }
 }
 
-export function stopProject(projectId: string, port: number): { success: boolean; error?: string } {
-  // Cancel any pending restart timer
-  const timer = restartTimers.get(projectId);
-  if (timer) { clearTimeout(timer); restartTimers.delete(projectId); }
-  restartCounts.delete(projectId);
+// stopProject timing budgets (#90). Real dev servers (esp. Next.js) can take
+// a moment to shut down gracefully on SIGTERM; SIGKILL should free the port
+// almost immediately once the OS reaps the process, so it gets a much
+// shorter window.
+const STOP_SIGTERM_TIMEOUT_MS = 4000;
+const STOP_SIGKILL_TIMEOUT_MS = 1500;
+const STOP_POLL_INTERVAL_MS = 150;
+const STOP_PORT_CHECK_TIMEOUT_MS = 300;
 
-  // First try to kill the tracked process
-  stoppingProjects.add(projectId);
-  const entry = activeProcesses.get(projectId);
-  if (entry && !entry.process.killed) {
-    try {
-      entry.process.kill('SIGTERM');
-      activeProcesses.delete(projectId);
-      addLogEntry(projectId, 'stdout', '[SYS] Process stopped via SIGTERM');
-      return { success: true };
-    } catch {
-      // Fall through to port-based kill
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Poll checkPort until it reports the port free, or timeoutMs elapses. */
+async function waitUntilPortFree(
+  port: number,
+  timeoutMs: number,
+  pollIntervalMs: number = STOP_POLL_INTERVAL_MS
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  // Always check at least once, even for a zero-length budget.
+  if (!(await checkPort(port, STOP_PORT_CHECK_TIMEOUT_MS))) return true;
+  while (Date.now() < deadline) {
+    await sleep(pollIntervalMs);
+    if (!(await checkPort(port, STOP_PORT_CHECK_TIMEOUT_MS))) return true;
+  }
+  return false;
+}
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}
+
+/**
+ * Signal a tracked child's whole process group, not just the tracked pid
+ * (#90). Children are spawned with `detached: true`, making them their own
+ * group leader on POSIX, so `-pid` reliably reaches the wrapper shell *and*
+ * whatever it execs/forks. Windows has no equivalent of negative-pid group
+ * signalling, so there we degrade to signalling just the tracked pid.
+ *
+ * A group/process that is already gone answers with ESRCH — that is treated
+ * as "already stopped," not an error, and is swallowed here. Any other
+ * failure (e.g. EPERM) is rethrown for the caller to log and route around.
+ */
+function signalProcessGroup(child: ChildProcess, signal: NodeJS.Signals): void {
+  const pid = child.pid;
+  if (!pid) return;
+
+  try {
+    if (process.platform === 'win32') {
+      child.kill(signal);
+    } else {
+      process.kill(-pid, signal);
     }
+  } catch (error) {
+    if (isErrnoException(error) && error.code === 'ESRCH') {
+      return;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Port-based fallback (#90). Finds whatever is actually listening on `port`
+ * via `ss` and SIGKILLs it directly. This is the only path available when
+ * there is no tracked entry at all — a server started before hexops
+ * launched, or orphaned by an earlier crash/restart — and it's also the
+ * last resort when a tracked kill escalated through SIGTERM+SIGKILL and
+ * still didn't free the port.
+ */
+async function stopByPort(projectId: string, port: number): Promise<{ success: boolean; error?: string }> {
+  if (!(await checkPort(port, STOP_PORT_CHECK_TIMEOUT_MS))) {
+    return { success: true };
   }
 
-  // Fallback: kill by port using ss (lsof often needs sudo)
-  // Security note: port is a number from config, not user string input
   try {
     let pids: string[] = [];
     try {
       // Use ss to find PIDs - format: users:(("process",pid=12345,fd=19))
+      // Security note: port is a number from config, not user string input
       const result = execFileSync('ss', ['-tlnp', `sport = :${port}`], {
         encoding: 'utf-8',
       });
-      // Extract PIDs from ss output using regex
       const pidMatches = result.matchAll(/pid=(\d+)/g);
       for (const match of pidMatches) {
         pids.push(match[1]);
@@ -309,27 +378,96 @@ export function stopProject(projectId: string, port: number): { success: boolean
       // ss may fail, which is fine
     }
 
-    if (pids.length > 0) {
-      for (const pid of pids) {
-        // Validate pid is numeric before using
-        if (/^\d+$/.test(pid)) {
-          try {
-            execFileSync('kill', ['-9', pid]);
-          } catch {
-            // Ignore errors (process may have already exited)
-          }
+    for (const pid of pids) {
+      // Validate pid is numeric before using
+      if (/^\d+$/.test(pid)) {
+        try {
+          execFileSync('kill', ['-9', pid]);
+        } catch {
+          // Ignore errors (process may have already exited)
         }
       }
-      activeProcesses.delete(projectId);
+    }
+
+    const freed = await waitUntilPortFree(port, STOP_SIGKILL_TIMEOUT_MS);
+    if (freed) {
       addLogEntry(projectId, 'stdout', `[SYS] Process killed via port ${port}`);
       return { success: true };
     }
 
-    return { success: false, error: 'No process found on port' };
+    return {
+      success: false,
+      error: pids.length > 0
+        ? `Sent SIGKILL to pid(s) ${pids.join(', ')} on port ${port}, but the port is still bound`
+        : `No process found on port ${port} via ss, but the port is still bound`,
+    };
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
     return { success: false, error: message };
   }
+}
+
+export async function stopProject(projectId: string, port: number): Promise<{ success: boolean; error?: string }> {
+  // Cancel any pending restart timer
+  const timer = restartTimers.get(projectId);
+  if (timer) { clearTimeout(timer); restartTimers.delete(projectId); }
+  restartCounts.delete(projectId);
+
+  const entry = activeProcesses.get(projectId);
+  const isLive = entry != null && entry.process.pid != null
+    && entry.process.exitCode === null && entry.process.signalCode === null;
+
+  if (entry && isLive) {
+    // Mark this projectId as an intentional stop *before* signalling, since
+    // the child's 'close' handler can fire at any point during the awaits
+    // below and needs to see this to avoid treating it as a crash. Only set
+    // when there's a live tracked process — a 'close' event will eventually
+    // clean this back up. (Setting it unconditionally, including for the
+    // port-only fallback below, would leak forever for a projectId with no
+    // tracked entry, silently disabling crash detection on a later start.)
+    stoppingProjects.add(projectId);
+
+    try {
+      signalProcessGroup(entry.process, 'SIGTERM');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      addLogEntry(projectId, 'stderr', `[SYS] Failed to send SIGTERM to process group: ${message}`);
+    }
+
+    let portFreed = await waitUntilPortFree(port, STOP_SIGTERM_TIMEOUT_MS);
+
+    if (!portFreed) {
+      addLogEntry(projectId, 'stdout', '[SYS] Still bound after SIGTERM — escalating to SIGKILL');
+      try {
+        signalProcessGroup(entry.process, 'SIGKILL');
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        addLogEntry(projectId, 'stderr', `[SYS] Failed to send SIGKILL to process group: ${message}`);
+      }
+      portFreed = await waitUntilPortFree(port, STOP_SIGKILL_TIMEOUT_MS);
+    }
+
+    if (portFreed) {
+      activeProcesses.delete(projectId);
+      addLogEntry(projectId, 'stdout', '[SYS] Process stopped');
+      return { success: true };
+    }
+
+    addLogEntry(
+      projectId,
+      'stderr',
+      '[SYS] Process group survived SIGTERM+SIGKILL — falling back to port-based kill'
+    );
+  }
+
+  // Port-based fallback — runs whenever the tracked route (or lack thereof)
+  // did not verifiably free the port, including when there is no tracked
+  // entry at all. Reporting success without this check is exactly bug #90.
+  const fallback = await stopByPort(projectId, port);
+  if (fallback.success) {
+    activeProcesses.delete(projectId);
+  }
+  return fallback;
 }
 
 // Strip ANSI escape codes for clean display
@@ -459,7 +597,7 @@ export interface DevServerGuardDeps {
   isSelf: (project: ProjectConfig) => boolean;
   isRunning: (projectId: string) => boolean;
   getMode: (projectId: string) => StartMode;
-  stop: (projectId: string, port: number) => { success: boolean; error?: string };
+  stop: (projectId: string, port: number) => Promise<{ success: boolean; error?: string }>;
   start: (project: ProjectConfig, mode: StartMode) => { success: boolean; error?: string };
   clearBuildDir: (projectPath: string) => void;
 }
@@ -531,7 +669,7 @@ export async function runWithDevServerGuard<T>(
 
   // orchestrate: capture the mode before stopping, restore in finally
   const mode = deps.getMode(project.id);
-  const stopResult = deps.stop(project.id, project.port);
+  const stopResult = await deps.stop(project.id, project.port);
   let result: T | undefined;
   let restarted = false;
   let restartError: string | undefined;

--- a/stop-fix-report.md
+++ b/stop-fix-report.md
@@ -268,3 +268,160 @@ output make the parent/child relationship unambiguous.)
    (`execFileSync` for `build`) works, and did not touch Windows behavior beyond
    the documented single-process degrade — neither was exercised by a real run
    (no Windows box here, and prod-mode build wasn't part of this bug).
+
+---
+
+## Addendum — response to independent review of `4e8c550`
+
+The review returned do-not-ship with two Critical and three Important findings.
+I agree with all five diagnoses (including that C2 was a real regression I
+introduced), fixed all five plus all four Minors, and added targeted
+regression coverage for each. Summary below; see the commit for the full diff.
+
+### C1 (Critical) — a shipped test could signal a real process group
+
+Confirmed: the "still bound after SIGTERM and SIGKILL" test was the one test
+in the file with no mock on `process.kill`, so after the previous test's
+`afterEach` ran `vi.restoreAllMocks()`, its `process.kill(-6666, 'SIGTERM'/
+'SIGKILL')` calls would hit the real syscall against a fabricated pid — on a
+box running ~35 real dev servers. This wasn't a per-test oversight I could
+patch one at a time with any confidence; I fixed it structurally.
+
+`process.kill` is now spied in the `stopProject` describe block's own
+`beforeEach`, before any test body runs, with a safe no-op default
+(`mockReturnValue(true)`, no side effects). Every test that needs custom
+kill behavior calls `.mockImplementation`/`.mockReturnValue` on that one
+shared `processKillSpy` — no test in this file calls `vi.spyOn(process,
+'kill')` a second time. The previously-unmocked test now inherits the safe
+default explicitly and unconditionally (and says so in a comment, so a
+future editor doesn't "helpfully" remove the now-apparently-redundant spy).
+`shutdownTrackedProcesses` and `signalProcessGroup`'s own describe blocks
+each spy `process.kill` locally per test, in the same pattern.
+
+### C2 (Critical) — the `stoppingProjects` guard was over-narrowed (regression, confirmed)
+
+Agreed with the diagnosis. I had gated `stoppingProjects.add` on `isLive`
+(tracked child, not yet exited), reasoning that only a live child has a
+`close` still pending. That reasoning was wrong: with `shell: true`, Node
+defers `'close'` until every stdio pipe finishes draining, and a grandchild
+holding those pipes open — while still holding the real port, exactly the
+#90 shape — can keep `close` pending well after the *direct* child
+(`exitCode`) already looks exited. Gating on `isLive` meant that routine
+case fell through unmarked: the deferred `close` later fired with
+`intentional=false`, producing a false "crashed" notification, and with
+`restartOnCrash` on, would relaunch the server the user had just
+deliberately stopped.
+
+Fixed exactly as suggested: `stoppingProjects.add(projectId)` now runs
+whenever a tracked `ChildProcess` exists at all (`if (entry)`), not only
+when it's live. Signalling itself is still gated on `isLive` (unchanged) —
+only the bookkeeping guard moved. Added
+`marks intentional even when the tracked child already looks exited but its
+close is still pending` in `process-manager.test.ts`, which constructs
+exactly that shape (tracked entry with `exitCode` already set, port freed
+via the fallback, then a late `close` fired manually) and asserts no crash
+notification fires. It fails against the `isLive`-gated version and passes
+now.
+
+### I1 (Important) — `stopByPort` could kill hexops itself
+
+Agreed — this was a real new route in, since the fallback is now reachable
+from a tracked stop whose group died but whose port is held by something
+else, not just the pre-existing fully-untracked-orphan case. Added an
+ownership guard in `stopByPort`: any pid `ss` reports that equals
+`process.pid` or `process.ppid` is skipped (logged, not killed) rather than
+sent `SIGKILL`. Each pid that *is* killed is now logged individually before
+the kill, for auditability. Covered by
+`refuses to kill hexops itself (or its parent) even if ss lists it on the port`.
+
+### I2 (Important) — `runWithDevServerGuard` ignored a failed stop
+
+Agreed — before #90 this branch was unreachable (stop effectively always
+"succeeded"), so it was never exercised. `runWithDevServerGuard` now checks
+`stopResult.success` immediately after awaiting it and, if false, returns
+`{ blocked: true, ranOperation: false, ... }` with a reason explaining the
+operation was refused because the server may still be live, without ever
+calling `operation()`. All four existing call sites (`override-remove`,
+`security/overrides/[id]/fix`, `update`, `security/cve-lite/[id]/fix`)
+already branch on `guardOutcome.blocked` generically (checked all four before
+making this change) and return a 409 with the reason, so none needed
+updating. One exception worth flagging separately: `override-remove/route.ts`
+does **not** check `blocked` at all before using `guardOutcome.result` — that
+gap pre-dates this change (it already mishandled `block-self` the same way)
+and is out of scope here, but it means a stop-failure on that specific route
+will currently return a misleading `{success:true, output:''}` rather than a
+409. Flagging for a follow-up, not fixing in this patch.
+
+Covered by `orchestrate: aborts (blocked, operation never runs) when stop
+fails to actually free the server` in the `runWithDevServerGuard` describe
+block.
+
+### I3 (Important) — `detached: true` orphans every server on Ctrl-C/terminal close
+
+Agreed, and the report's original claim was wrong — corrected here.
+`detached: false` didn't prevent orphaning on its own, but it kept tracked
+children in hexops's own foreground process group and session, so a
+terminal Ctrl-C (SIGINT to the foreground group) or terminal close (SIGHUP
+to the session) reaped them as a side effect, without any explicit cleanup
+code. `detached: true` calls `setsid()`, which severs both — Ctrl-C no
+longer reaches tracked children at all once this patch landed, and there
+was no code anywhere filling that gap.
+
+Added `shutdownTrackedProcesses(signal)`, which group-signals every
+currently-tracked child, and wired it to real `SIGINT`/`SIGTERM` with
+`process.exit()` afterward — but only outside test runs
+(`process.env.VITEST === 'true' || process.env.NODE_ENV === 'test'`) and
+only on POSIX. Registering unconditionally would have installed a real
+`process.on('SIGTERM', ...)` handler on every vitest worker process that
+imports this module, calling `process.exit()` — and vitest's own pool
+workers are routinely sent `SIGTERM` for normal lifecycle reasons (timeouts,
+`--watch` restarts, teardown), so intercepting that unconditionally would
+have been its own hazard. `shutdownTrackedProcesses` itself is exported and
+tested directly (`signals the process group of every currently tracked
+child`) without going through a real OS signal.
+
+### Minors
+
+- **M1** — applied exactly as suggested: the `close` handler now guards
+  `activeProcesses.delete(project.id)` on `activeProcesses.get(project.id)
+  ?.process === child`, so a late `close` from a superseded child can't
+  untrack its replacement.
+- **M2** — reverted the tightened 300ms `checkPort` timeout back to its
+  1000ms default everywhere `stopProject`/`stopByPort` call it (removed the
+  `STOP_PORT_CHECK_TIMEOUT_MS` override entirely). Agreed a shortened
+  per-attempt timeout was a false-success path in exactly the function meant
+  to eliminate them.
+- **M3** — `stopProject`'s tracked-success path now also confirms the
+  process itself, not just the port: once the port is free, it waits up to
+  500ms (`STOP_PROCESS_EXIT_GRACE_MS`) for `exitCode`/`signalCode` to be set,
+  and if it still hasn't exited, sends one more defensive `SIGKILL` before
+  reporting success (still port-gated per #90's actual contract, but no
+  longer silently trusting a released port over a `ChildProcess` handle we
+  are already holding). Covered by `port released but the process itself has
+  not exited yet: sends a defensive final SIGKILL`.
+- **M4** — exported `signalProcessGroup` (documented as test-only, not part
+  of the module's intended public surface) and added two direct unit tests
+  pinning that ESRCH is swallowed and EPERM is rethrown — the previous ESRCH
+  test only proved the *overall* stop still succeeded (via mocked
+  `checkPort`), which would have passed identically whether ESRCH was
+  swallowed inside `signalProcessGroup` or merely caught by `stopProject`'s
+  outer try/catch. Also added an integration-level EPERM test (`an EPERM on
+  the tracked group kill does not crash stopProject`) covering the case the
+  review called out as unprotected and most dangerous: a real signalling
+  failure that must log and fall through to the port-based fallback rather
+  than crashing or hanging.
+
+### Verification after the addendum fixes
+
+- Full suite: **399 passed / 46 files** (was 391/46; +8 new tests — 4 in the
+  `stopProject` block, 2 in a new `signalProcessGroup` block, 1 in a new
+  `shutdownTrackedProcesses` block, 1 in `runWithDevServerGuard`). Nothing
+  removed or weakened.
+- `tsc --noEmit`: clean.
+- Re-ran the real-process verification (same scratch port 39123, same
+  `sh(parent) -> node(child)` shape) against the fixed code: `stopProject ->
+  {"success":true}`, port confirmed released, tracked wrapper pid and all
+  real child pids confirmed dead by `kill -0`, hexops' own port-3000 server
+  confirmed untouched throughout. Same PASS outcome as the original
+  transcript, now against code that also survives the C1/C2/I1/I2/I3/M1–M4
+  fixes.

--- a/stop-fix-report.md
+++ b/stop-fix-report.md
@@ -1,0 +1,270 @@
+# #90 — Stop returns success while next-server keeps running
+
+## Root cause (confirmed)
+
+`startProject` spawned with `shell: true, detached: false`. With `shell: true` the
+tracked `child.pid` is the `sh -c "<command>"` wrapper, not the real dev server it
+execs/forks. `stopProject` signalled only that tracked pid with `SIGTERM`, which
+POSIX `sh` does not forward to its child, then returned `{ success: true }`
+immediately, without ever checking whether the port was actually released. The
+`ss` + `kill -9` fallback only ran when the tracked kill *threw*, which it never
+does — so in the common case it was dead code.
+
+## What changed, per function
+
+### `startProject` (`src/lib/process-manager.ts`)
+
+- `detached: false` → `detached: true`. On POSIX this makes the spawned child its
+  own process-group leader (`pid === pgid`), so the whole tree — `sh` and whatever
+  it forks — can be signalled together via `process.kill(-pid, …)`.
+- **Did not** call `child.unref()`. stdout/stderr must keep flowing into the log
+  buffer for as long as hexops is running; `unref()` would only affect whether the
+  event loop keeps the parent alive on the child's account, which is irrelevant
+  here since hexops itself is a long-lived server, but it's also irrelevant to the
+  signal-forwarding fix, so I left it untouched per the constraint.
+- No other change to the spawn call — `withoutInheritedBundlerEnv` (#111) and the
+  `execFileSync` production build step are both untouched.
+
+**Decision on `detached: true` orphaning consequence:** accepted. A detached child
+is no longer auto-killed when hexops's own process exits. I concluded this is
+correct for HexOps's actual job (managing long-lived dev servers independently of
+its own lifecycle/restarts), and — concretely — the *old* `shell: true` setup was
+**already** orphaning the real process in practice; that's precisely the incident
+this bug report describes (two orphaned `sh -c node` / `node server.js` pairs
+found alive after a supposed stop). Making the child detached doesn't introduce a
+new failure mode; it makes an existing one **fixable**, because now there is a
+single well-defined process group to signal instead of an untrackable descendant.
+
+### `stopProject` — now `async`, returns `Promise<{ success, error? }>`
+
+New flow:
+
+1. Cancel any pending restart timer / clear restart count (unchanged).
+2. If there's a **live** tracked entry (`pid` set, `exitCode === null`,
+   `signalCode === null`):
+   - Mark `stoppingProjects` **only now** (see bookkeeping note below), then
+     `signalProcessGroup(entry.process, 'SIGTERM')`.
+   - Poll `checkPort` (via new `waitUntilPortFree`) for up to 4s.
+   - If still bound, escalate: `signalProcessGroup(entry.process, 'SIGKILL')`,
+     poll again for up to 1.5s.
+   - If the port is free at either point → `activeProcesses.delete`, return
+     `{ success: true }`.
+   - If still bound after both escalations → fall through (no early return).
+3. **Port-based fallback (`stopByPort`)** — now a real path, not catch-only. Runs
+   whenever step 2 didn't verifiably free the port, *including when there is no
+   tracked entry at all* (orphan from before hexops launched, or from an earlier
+   crash — exactly today's incident). Same `ss -tlnp` + `kill -9` approach as
+   before, but now also polls `checkPort` afterward and only reports success if
+   the port is actually free. If `ss` finds nothing and the port is still bound,
+   or if it kills something and the port is *still* bound, it returns
+   `{ success: false, error: '...' }`.
+
+New helpers:
+
+- `signalProcessGroup(child, signal)` — POSIX: `process.kill(-pid, signal)`
+  (group). Windows: `child.kill(signal)` (single process — `process.kill(-pid)`
+  is POSIX-only and would throw/behave unexpectedly on Windows, so it degrades
+  rather than crashing). Swallows `ESRCH` ("already gone" = already stopped, not
+  an error); rethrows anything else (e.g. `EPERM`) for the caller to log and
+  route around via the port-based fallback.
+- `waitUntilPortFree(port, timeoutMs, pollIntervalMs)` — polls `checkPort` (from
+  `src/lib/port-checker.ts`) until it reports free or the budget elapses.
+- `stopByPort(projectId, port)` — the promoted fallback described above.
+
+Timing budgets: `STOP_SIGTERM_TIMEOUT_MS = 4000`, `STOP_SIGKILL_TIMEOUT_MS =
+1500`, poll every `150ms`. Chosen to give a real Next.js dev server a fair chance
+to shut down gracefully on SIGTERM, while keeping the SIGKILL confirmation window
+short since a killed process frees its socket almost immediately.
+
+### `runWithDevServerGuard` / `DevServerGuardDeps`
+
+Read it before touching it, per the brief. `deps.stop` type changed to
+`(projectId, port) => Promise<{ success, error? }>`; the one call site
+(`const stopResult = deps.stop(...)`) became `await deps.stop(...)`. The
+guard's own control flow was already fully `async`/`await`-based (it already
+`await`s `operation()` and is itself declared `async`), so this was a
+one-line change — nothing else in the guard assumed synchronous stop.
+`defaultDevServerGuardDeps.stop = stopProject` still type-checks since
+`stopProject` now returns a `Promise` natively.
+
+### Call sites updated
+
+- `src/app/api/projects/[id]/stop/route.ts:32` —
+  `const result = stopProject(...)` → `const result = await stopProject(...)`.
+- `src/lib/process-manager.ts:471` (`defaultDevServerGuardDeps.stop`) — no code
+  change needed beyond the type; `stopProject` already matches the new async
+  signature.
+
+## Restart flow / `stoppingProjects` bookkeeping
+
+- **Pending restart cancel**: unchanged, still the first thing `stopProject`
+  does (`clearTimeout` + `restartTimers.delete` + `restartCounts.delete`),
+  before any signalling/awaiting. Verified: if `stopProject` is called while a
+  restart timer is pending, there's usually no tracked entry left (`close`
+  already ran and deleted it), so execution goes straight to `stopByPort`,
+  which sees the port already free and returns `{ success: true }` fast,
+  without needing `ss`.
+- **`stoppingProjects` and the async boundary — found and fixed a real bug
+  while implementing this.** The original code called
+  `stoppingProjects.add(projectId)` *unconditionally* at the top of
+  `stopProject`, before even checking whether there was a tracked entry. That
+  flag is only ever cleared by the child's `'close'` handler. For the
+  **no-tracked-entry** path (an orphan with no `ChildProcess` object — exactly
+  the scenario the port-based fallback is now designed to handle as a first-
+  class case) there is no `'close'` event coming, ever, for that stop
+  attempt — so the flag would leak forever. If that `projectId` was later
+  started for real and *genuinely* crashed, the crash handler would read
+  `stoppingProjects.has(projectId) === true` from the stale orphan-stop and
+  silently treat the crash as "intentional," suppressing the crash
+  notification and auto-restart with no observable cause. This bug pre-dates
+  my change but the port-fallback becoming a *primary* path for exactly this
+  scenario makes it far more likely to bite in practice, so I fixed it: I now
+  only call `stoppingProjects.add(projectId)` right before signalling a
+  **live** tracked entry, i.e. only in the branch that has a real `'close'`
+  event coming to clean it back up. This is covered by a new regression test
+  (`an untracked/orphan stop does not poison crash detection for a later real
+  process with the same id`), which fails against the old unconditional-`add`
+  behavior and passes now.
+- Order-of-events concern ("`close` may now fire at a different time relative
+  to `stopProject` returning"): this was already inherently async even before
+  my change (Node's `'close'` event needs at least one event-loop turn after
+  `kill()`). My change makes it *more* likely `'close'` has already fired by
+  the time `stopProject` resolves (since we now actively poll for hundreds of
+  ms to seconds before returning) rather than less — which is fine, since the
+  `'close'` handler's `activeProcesses.delete` / `stoppingProjects.delete`
+  calls are idempotent and `stopProject` doesn't rely on ordering relative to
+  it, only on the `checkPort` poll result.
+
+## Windows
+
+`signalProcessGroup` branches on `process.platform === 'win32'` and uses
+`child.kill(signal)` (single process, not a negative pid) there, so a non-POSIX
+platform degrades gracefully instead of crashing on an invalid `process.kill(-pid,
+…)` call. Not exercised by a real Windows run (this project targets Linux/WSL2
+per the brief) but the branch is simple and directly testable if needed later.
+
+## TURBOPACK env fix (#111) / prod build step
+
+Untouched. `withoutInheritedBundlerEnv(process.env)` is still spread into the
+long-lived `spawn` call's `env`. The prod-mode build step's `execFileSync` call
+(synchronous, run before the dev/start script spawn) is unchanged — I only
+touched the long-lived `spawn` options and added a *second*, separate use of
+`execFileSync` inside `stopByPort` for the `ss`/`kill -9` fallback, which existed
+before too (same shape, just promoted from catch-only to a real path).
+
+## Testing
+
+### Unit tests (`src/lib/process-manager.test.ts`)
+
+`child_process.spawn`/`execFileSync`, `./port-checker`'s `checkPort`, and
+`./notifications`'s `addNotification` are mocked (`vi.mock` + `vi.hoisted`); no
+real process is spawned and no real port is bound in the unit suite. A tracked
+entry is created via the *real* `startProject` path with a fake
+`EventEmitter`-based `ChildProcess` stand-in, so `activeProcesses`/`close`
+bookkeeping runs unmodified. Fake timers (`vi.useFakeTimers` +
+`vi.advanceTimersByTimeAsync`) are used for the two tests that exercise the
+SIGTERM→SIGKILL escalation windows, so the suite stays fast.
+
+Added 9 tests, all requested cases covered:
+
+1. `spawns with detached: true so the whole process tree can be signalled`
+2. `signals the whole process group (-pid), not the bare pid`
+3. `returns success once the port is actually released after SIGTERM`
+4. `escalates to SIGKILL when the port is still bound after SIGTERM`
+5. `returns success: false with an error when the port is still bound after
+   SIGTERM and SIGKILL`
+6. `treats ESRCH from the kill syscall as already-stopped, not a failure`
+7. `runs the port-based fallback when there is no tracked entry at all (e.g.
+   an orphaned server)`
+8. `reports failure (not success) when the port-based fallback finds nothing
+   and the port stays bound` (bonus — untracked-orphan version of case 5)
+9. `an untracked/orphan stop does not poison crash detection for a later real
+   process with the same id` (the `stoppingProjects` bookkeeping regression
+   test described above)
+
+Full suite: **391 passed / 46 files** (baseline 382/46 + 9 new). Nothing deleted
+or weakened.
+
+`pnpm typecheck` (`tsc --noEmit`): **clean**, no errors.
+
+### Real-process verification (required — mocked-spawn tests can't catch this class of bug)
+
+Ran the real `startProject`/`stopProject` (via `tsx`, no mocks) against a
+trivial Node HTTP listener on port **39123** (never 3000), spawned exactly like
+a real project: `dev: "echo starting && node server.js"` under `shell: true` —
+the `&&` forces `/bin/sh` to actually fork a child instead of tail-call-exec'ing
+into `node`, reproducing the real `sh(parent) → node(child)` shape from the
+incident. Script + harness live in the scratchpad
+(`/tmp/claude-1000/.../scratchpad/verify90/`), not in this repo. hexops' own
+dev server on port 3000 was left completely untouched throughout (confirmed
+before and after).
+
+Transcript (trimmed of noise):
+
+```
+=== #90 real-process verification ===
+Target port: 39123 (never 3000)
+startProject -> {"success":true}
+Port 39123 bound within 5s: true
+Tracked pid (this is the `sh` wrapper pid, not node): 495119
+
+--- ss before stop ---
+LISTEN 0 511 *:39123 *:* users:(("MainThread",pid=495120,fd=21))
+
+--- process tree before stop (pstree) ---
+sh(495119)---MainThread(495120)-+-{MainThread}(495121)
+                                 |-{MainThread}(495122)
+                                 |-{MainThread}(495123)
+                                 |-{MainThread}(495124)
+                                 |-{MainThread}(495125)
+                                 `-{MainThread}(495126)
+Wrapper pid: 495119, real child pid(s) found via pstree: 495120, 495121, 495122, 495123, 495124, 495125, 495126
+
+calling real stopProject...
+stopProject -> {"success":true}
+
+--- ss after stop ---
+(empty)
+Port 39123 still listening after stop: false
+
+--- orphan check: is the specific wrapper pid or its specific child pid(s) still alive? ---
+wrapper pid 495119 alive: false
+child pid(s) still alive: (none — all gone)
+
+isTracked after stop: false
+
+=== RESULT: PASS ===
+```
+
+Confirmed separately afterward: `ss -tlnp 'sport = :3000'` still shows the
+original hexops dev server's `MainThread` listener untouched; `ss -tlnp 'sport =
+:39123'` is empty; no leftover processes referencing the scratch app dir.
+
+(Note: `ss -p` on this WSL2 box reports Node's main OS thread as
+`"MainThread"` rather than `"node"` — a cosmetic quirk of this environment's
+`ss`/procfs, not a correctness issue; the pid identity checks and `pstree`
+output make the parent/child relationship unambiguous.)
+
+## Things I'm unsure about / would flag for review
+
+1. **Timing budgets are a judgment call.** 4s for SIGTERM + 1.5s for SIGKILL
+   confirmation is reasonable for Next dev servers in practice, but a project
+   with an unusually slow graceful-shutdown path could still get force-killed
+   sooner than ideal. These aren't currently configurable per-project; if a
+   project needs a longer grace period this would be the place to add a setting.
+2. **`stopByPort`'s `ss` output parsing is unchanged from the original** (regex
+   `pid=(\d+)` over `ss -tlnp` output) — it's still a heuristic string parse, not
+   hardened against unusual `ss` output formats. I didn't expand its robustness
+   beyond making it a real (polled-and-verified) path, since that was explicitly
+   in scope and re-parsing `ss` output wasn't.
+3. **The pre-existing `stoppingProjects` leak I fixed** was not explicitly called
+   out in the bug report, but I judged it directly load-bearing for the
+   port-fallback becoming a first-class path (it's now hit routinely for the
+   orphan/no-tracked-entry case the incident describes). Flagging it explicitly
+   in case there's a reason it was left as-is that I'm not seeing — I don't see
+   one, and the regression test demonstrates the failure mode concretely, but
+   it's a slightly larger blast radius than the literal ask.
+4. I did not change anything about how `startProject`'s production build step
+   (`execFileSync` for `build`) works, and did not touch Windows behavior beyond
+   the documented single-process degrade — neither was exercised by a real run
+   (no Windows box here, and prod-mode build wasn't part of this bug).


### PR DESCRIPTION
Closes #90 — "Stop returns success while next-server keeps running."

## The bug, in four layers

1. `startProject` spawned with `{ shell: true, detached: false }`, so `child.pid` was the **`sh -c` wrapper**, not the real `next-server`.
2. `stopProject` sent `SIGTERM` to that wrapper. POSIX `sh` doesn't forward signals, so the server survived and kept its port.
3. It then returned `{ success: true }` **having verified nothing**.
4. The `ss`/`kill -9` fallback only ran if the tracked kill *threw*, which it never did — dead code in the common case.

Observed live yesterday: two orphaned `sh -c node` / `node server.js` pairs held port 3000, a plain SIGTERM couldn't reach them, and a fresh start failed with `EADDRINUSE`.

## The fix

- **`detached: true`** so the child is a process-group leader.
- **Group kill** — `process.kill(-pid, …)` reaches the whole tree. Windows degrades to a single-process kill.
- **Verified success** — poll `checkPort` after signalling, escalate SIGTERM → SIGKILL, and return `success: false` with a clear error if the port is *still* bound. Reporting success while a server lives was the entire bug.
- **The port-based fallback is now a real path**, including when there's no tracked entry at all — an orphan from a crash, or a server started before HexOps launched.
- `stopProject` is now async; its caller and `runWithDevServerGuard` updated.

Also fixed along the way: `stoppingProjects` leaked permanently for untracked ids, suppressing the next genuine crash notification for that project.

## Review found five blockers, all fixed

Two were serious enough to call out:

- **A shipped test executed `process.kill(-6666, 'SIGKILL')` for real.** It asserted only `success === false`, which held whether the signal hit nothing or destroyed an unrelated process tree — so it could never fail because of it. On a box running ~35 dev servers that's a live hazard. `process.kill` is now mocked structurally in a shared `beforeEach`; verified with a tripwire config that traps the real syscall — 31 tests, zero hits.
- **A deliberate Stop was misreported as a crash.** `stoppingProjects` was gated on "is the child live" rather than "does a tracked child exist". With `shell: true` the wrapper can exit while a grandchild holds the pipes *and* the port — the #90 shape itself — so `'close'` fired with `intentional: false`, and with `restartOnCrash` enabled it **relaunched the server the user just stopped**. Verified by reverting the guard in a temp copy and watching the new test fail with exactly that notification.

Plus: `stopByPort` now refuses `process.pid`/`process.ppid` (a project misconfigured to :3000 would have made HexOps kill its own server); `runWithDevServerGuard` aborts rather than running `pnpm install` against a still-live server (newly reachable, since a failed stop is now a real outcome); and a `SIGINT`/`SIGTERM` handler reaps tracked children, because `setsid()` severed the foreground group that used to do it.

## Verification

**399 tests / 46 files**, `tsc --noEmit` clean, `pnpm build` exit 0.

Real processes, not mocks — SIGKILL escalation against a SIGTERM-ignoring server on a scratch port: `stopProject` returned success after 4.2s, port free, all 8 group pids dead.

## Known follow-ups (issues to file)

- **M3 is ineffective in the real shape.** The process-exit confirmation checks the tracked child, which under `shell: true` is the `sh` wrapper — killed instantly by the group SIGTERM, so the guard always passes. A server that closes its listener then hangs returns `success: true` with the port free and the process still alive. Only affects servers that trap SIGTERM (a stock Next dev server doesn't), but it's a narrower instance of #90.
- **The SIGINT/SIGTERM handler leaks listeners across module re-evaluation.** Registration is module-scoped, so an HMR reload adds another; the oldest wins and holds a stale process map, silently reaping nothing. SIGHUP is unhandled.
- `override-remove` doesn't check `blocked`, so a failed guard-stop surfaces as success there.
- A failed guard-stop skips the restart in `finally`.
- `shell: false` projects are force-killed 500ms after releasing their port.